### PR TITLE
[LFXV2-11] Minor updates to complete integration with Project Service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Essential Commands
+
+### Development Workflow
+
+```bash
+# Setup and build
+make setup                    # Download dependencies and setup environment
+make build-local             # Build for local development
+make run                     # Run service locally with environment setup
+
+# Code quality (run before committing)
+make lint                    # Run golangci-lint (install if needed)
+make test                    # Run all tests with race detection and coverage
+make quality                 # Run fmt, vet, lint, and test together
+
+# Layer-specific testing
+make test-domain             # Test business logic only
+make test-infrastructure     # Test external integrations
+make test-application        # Test workflow coordination
+make test-presentation       # Test message handlers
+
+# Production builds
+make build                   # Build for Linux deployment (Docker)
+make docker-build           # Build container image
+make helm-install           # Deploy using Helm chart
+```
+
+### Debugging and Health Checks
+
+```bash
+# Configuration validation
+./bin/lfx-indexer -check-config
+
+# Health endpoints
+curl http://localhost:8080/livez    # Kubernetes liveness probe
+curl http://localhost:8080/readyz   # Kubernetes readiness probe
+curl http://localhost:8080/health   # General health status
+
+# Debug logging
+LOG_LEVEL=debug make run
+```
+
+## Architecture Overview
+
+This is a **Clean Architecture** implementation processing NATS messages into OpenSearch documents. The service handles both modern V2 messages (`lfx.index.*`) and legacy V1 messages (`lfx.v1.index.*`) with queue group load balancing.
+
+### Layer Boundaries (Dependency Rule: Inner layers cannot depend on outer layers)
+
+1. **Domain Layer** (`internal/domain/`): Pure business logic and interfaces
+   - `contracts/`: Core entities (`LFXTransaction`, `TransactionBody`) and repository interfaces
+   - `services/indexer_service.go`: Central business logic (1100+ lines)
+
+2. **Application Layer** (`internal/application/`): Use case orchestration
+   - `message_processor.go`: Coordinates V2/V1 message processing workflows
+
+3. **Infrastructure Layer** (`internal/infrastructure/`): External service adapters
+   - `messaging/`: NATS client with queue group support
+   - `storage/`: OpenSearch document indexing
+   - `auth/`: JWT validation against Heimdall service
+   - `cleanup/`: Background conflict resolution
+
+4. **Presentation Layer** (`internal/presentation/handlers/`): Protocol concerns
+   - `indexing_message_handler.go`: NATS message handling
+   - `health_handler.go`: Kubernetes health endpoints
+
+### Message Processing Flow
+
+```
+NATS → MessagingRepository → IndexingMessageHandler → MessageProcessor → IndexerService → [Enricher] → OpenSearch
+```
+
+### Critical Patterns
+
+**Message Routing**: Subject prefix determines version (`lfx.index.*` = V2, `lfx.v1.index.*` = V1)
+
+**Enricher System**: Extensible data processing based on object type
+
+- Current: `ProjectEnricher`, `ProjectSettingsEnricher`
+- Register new enrichers in `IndexerService.NewIndexerService()`
+
+**Authentication**:
+
+- V2: JWT tokens via `Authorization` header (validated against Heimdall)
+- V1: Simple `X-Username`/`X-Email` headers
+- Delegation: `X-On-Behalf-Of` support
+
+**Configuration**: CLI flags > Environment variables > Defaults
+
+## Required Environment Variables
+
+```bash
+# Core services (required)
+NATS_URL=nats://nats:4222
+OPENSEARCH_URL=http://localhost:9200
+JWKS_URL=http://localhost:4457/.well-known/jwks
+
+# Message processing
+NATS_QUEUE=lfx.indexer.queue
+OPENSEARCH_INDEX=resources
+NATS_INDEXING_SUBJECT=lfx.index.>
+NATS_V1_INDEXING_SUBJECT=lfx.v1.index.>
+
+# Optional configuration
+PORT=8080
+LOG_LEVEL=info
+JANITOR_ENABLED=true
+```
+
+## Development Guidelines
+
+### Clean Architecture Rules
+
+- Domain layer cannot import from infrastructure/presentation layers
+- All external dependencies must use repository interfaces
+- Business logic stays in domain services
+- Dependency injection only in `cmd/lfx-indexer/main.go`
+
+### Adding New Object Types
+
+1. Add constant to `pkg/constants/messaging.go`
+2. Create enricher in `internal/enrichers/` implementing `Enricher` interface
+3. Register enricher in `IndexerService.NewIndexerService()`
+4. Add tests for the new enricher
+
+### Message Processing Requirements
+
+- Always reply to NATS messages with "OK" or "ERROR: details"
+- Log comprehensive context for debugging (action, object_type, message_id)
+- Handle both V2 (past-tense actions) and V1 (present-tense actions) formats
+- Support base64-encoded data fields
+
+### Testing Strategy
+
+- Use layer-specific make targets for focused testing
+- Mock external dependencies using interfaces in `internal/mocks/`
+- Test both V2 and V1 message formats where applicable
+- Include race detection in all test runs
+
+## Key Files for Understanding the System
+
+- `internal/domain/services/indexer_service.go`: Core business logic
+- `internal/application/message_processor.go`: Message workflow orchestration  
+- `internal/domain/contracts/transaction.go`: Core business entities
+- `internal/enrichers/registry.go`: Enricher registration and lookup
+- `internal/infrastructure/config/app_config.go`: Configuration management
+- `cmd/lfx-indexer/main.go`: Dependency injection and service startup

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: MIT
 
 # Variables
-APP_NAME := lfx-indexer
-VERSION := $(shell git describe --tags --always --dirty)
+APP_NAME := lfx-v2-indexer-service
+VERSION := 0.1.0
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 GIT_COMMIT := $(shell git rev-parse HEAD)
 
 # Docker
-DOCKER_REGISTRY := ghcr.io/linuxfoundation
+DOCKER_REGISTRY := linuxfoundation
 DOCKER_IMAGE := $(DOCKER_REGISTRY)/$(APP_NAME)
 DOCKER_TAG := $(VERSION)
 
@@ -213,6 +213,19 @@ docker-stop: ## Stop Docker container
 	docker stop $(APP_NAME) || true
 	docker rm $(APP_NAME) || true
 
+##@ Helm
+
+.PHONY: helm-install
+helm-install: ## Install the application using Helm
+	@echo "Installing application using Helm..."
+	helm upgrade --install lfx-v2-indexer-service charts/lfx-v2-indexer-service
+
+.PHONY: helm-uninstall
+helm-uninstall: ## Uninstall the application using Helm
+	@echo "Uninstalling application using Helm..."
+	helm uninstall lfx-v2-indexer-service
+
+
 ##@ Development Tools
 
 .PHONY: dev-setup
@@ -302,4 +315,4 @@ outdated: ## Check for outdated dependencies
 .PHONY: licenses
 licenses: ## Show dependency licenses
 	@echo "Showing dependency licenses..."
-	go-licenses report ./... || echo "Install go-licenses: go install github.com/google/go-licenses@latest" 
+	go-licenses report ./... || echo "Install go-licenses: go install github.com/google/go-licenses@latest"

--- a/README.md
+++ b/README.md
@@ -5,22 +5,25 @@ A high-performance, indexer service for the LFX V2 platform that processes resou
 ## 📋 Overview
 
 The LFX V2 Indexer Service is responsible for:
+
 - **Message Processing**: NATS stream processing with queue group load balancing across multiple instances
 - **Transaction Enrichment**: JWT authentication, data validation, and principal parsing with delegation support
 - **Search Indexing**: OpenSearch document indexing with optimistic concurrency control  
-- **Data Consistency**: Event-driven janitor service for conflict resolution 
+- **Data Consistency**: Event-driven janitor service for conflict resolution
 - **Dual Format Support**: Both LFX v2 (past-tense actions) and legacy v1 (present-tense actions) message formats
 - **Health Monitoring**: Kubernetes-ready health check endpoints
 
 ## 🚀 Quick Start
 
 ### Prerequisites
+
 - **Go 1.24**
 - **NATS Server** (message streaming)  
 - **OpenSearch/Elasticsearch** (document indexing)
 - **Heimdall JWT Service** (authentication)
 
 ### Environment Setup
+
 ```bash
 # Core Services (Required)
 export NATS_URL=nats://nats:4222
@@ -37,6 +40,7 @@ export PORT=8080
 ```
 
 ### Install & Run
+
 ```bash
 # Install dependencies
 go mod download
@@ -58,6 +62,7 @@ go build -o bin/lfx-indexer ./cmd/lfx-indexer
 ```
 
 ### CLI Flags
+
 ```bash
 # Service configuration
 ./bin/lfx-indexer -p 9090              # Custom health check port
@@ -75,6 +80,7 @@ go build -o bin/lfx-indexer ./cmd/lfx-indexer
 **Note**: CLI flags have highest precedence: `CLI flags > Environment variables > Defaults`
 
 ### Health Check
+
 ```bash
 # Kubernetes probes
 curl http://localhost:8080/livez    # Liveness probe
@@ -83,7 +89,6 @@ curl http://localhost:8080/health   # General health
 ```
 
 ## 🏗️ Architecture Overview
-
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -339,6 +344,7 @@ JANITOR_ENABLED=true                         # Enable cleanup service (default: 
 | `lfx.v1.index.*` | V1 legacy support | `lfx.v1.index.project` | Queue group distribution |
 
 **Queue Group**: `lfx.indexer.queue`
+
 - **Load Balancing**: Automatic distribution across service instances
 - **Durability**: Messages processed exactly once per queue group  
 - **Fault Tolerance**: Failed instances don't lose messages
@@ -488,6 +494,7 @@ nats sub "lfx.index.>" --server nats://your-nats-server:4222
 ### Common Issues
 
 **1. NATS Connection Failures**
+
 ```bash
 # Check NATS connectivity
 nats server check --server $NATS_URL
@@ -501,6 +508,7 @@ nats sub test.subject --server $NATS_URL
 ```
 
 **2. OpenSearch Issues**
+
 ```bash
 # Check OpenSearch health
 curl $OPENSEARCH_URL/_cluster/health
@@ -513,6 +521,7 @@ curl $OPENSEARCH_URL/resources/_search?size=5&sort=@timestamp:desc
 ```
 
 **3. JWT Validation Failures**
+
 ```bash
 # Check Heimdall connectivity
 curl $JWKS_URL
@@ -524,6 +533,7 @@ LOG_LEVEL=debug ./bin/lfx-indexer
 ### Performance Monitoring
 
 **Health Endpoints:**
+
 ```bash
 curl http://localhost:8080/livez    # Kubernetes liveness
 curl http://localhost:8080/readyz   # Kubernetes readiness  
@@ -531,6 +541,7 @@ curl http://localhost:8080/health   # General health status
 ```
 
 **Debug Configuration:**
+
 ```bash
 # Enable comprehensive debugging
 export LOG_LEVEL=debug
@@ -543,17 +554,20 @@ LOG_LEVEL=debug make run
 ## 🔒 Security
 
 **JWT Authentication:**
+
 - **Heimdall Integration**: All messages validated against JWT service
 - **Multiple Audiences**: Configurable audience validation
 - **Principal Parsing**: Authorization header and X-On-Behalf-Of delegation support
 - **Machine User Detection**: `clients@` prefix identification
 
 **Input Validation:**
+
 - **Domain Validation**: LFXTransaction entity validates all inputs
 - **Subject Format Validation**: String prefix validation with enhanced error messages
 - **Data Structure Validation**: Comprehensive JSON schema validation
 
 **Error Handling:**
+
 - **Safe Error Messages**: No sensitive data leakage
 - **Structured Logging**: Detailed error context for debugging
 - **Graceful Degradation**: Continue processing on non-critical failures
@@ -561,27 +575,27 @@ LOG_LEVEL=debug make run
 ## 🐳 Deployment
 
 ### Helm Chart
-```bash
-# Install with Helm
-helm install lfx-indexer ./charts/lfx-v2-indexer-service \
-  --namespace lfx \
-  --create-namespace
 
-# Install with custom values
+```bash
+# Install with Make
+make helm-install
+
+# Uninstall with Make
+make helm-uninstall
+
+# Manual installation with custom namespace/values
 helm install lfx-indexer ./charts/lfx-v2-indexer-service \
   --namespace lfx \
   --create-namespace \
   --values custom-values.yaml
 
-# Upgrade
+# Manual upgrade
 helm upgrade lfx-indexer ./charts/lfx-v2-indexer-service \
   --namespace lfx
-
-# Uninstall
-helm uninstall lfx-indexer --namespace lfx
 ```
 
 ### Docker
+
 ```bash
 # Build container
 make docker-build
@@ -599,18 +613,21 @@ docker run -p 8080:8080 \
 This project uses dual licensing to cover different types of content:
 
 ### Software License (MIT)
+
 The source code in this project is licensed under the **MIT License**. See the [LICENSE](LICENSE) file for the complete license text.
 
 **Copyright**: The Linux Foundation and each contributor to LFX.
 
 ### Documentation License (Creative Commons)
+
 The documentation in this project is licensed under the **Creative Commons Attribution 4.0 International License**. See the [LICENSE-docs](LICENSE-docs) file for the complete license text.
 
-
 ### Security Policy
+
 For information about reporting security vulnerabilities, please see our [SECURITY.md](SECURITY.md) file.
 
 ### Code Ownership
+
 Code review and maintenance responsibilities are defined in the [CODEOWNERS](CODEOWNERS) file.
 
 ---

--- a/charts/lfx-v2-indexer-service/values.yaml
+++ b/charts/lfx-v2-indexer-service/values.yaml
@@ -22,7 +22,7 @@ nats:
 # opensearch is the configuration for the OpenSearch server
 opensearch:
   # url is the URL of the OpenSearch server
-  url: http://opensearch.lfx.svc.cluster.local:9200
+  url: http://opensearch-cluster-master.lfx.svc.cluster.local:9200/
   # index is the index name for storing resources
   index: resources
 

--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -75,6 +75,7 @@ func NewIndexerService(
 	// Initialize enricher registry with project enricher
 	registry := enrichers.NewRegistry()
 	registry.Register(enrichers.NewProjectEnricher())
+	registry.Register(enrichers.NewProjectSettingsEnricher())
 
 	return &IndexerService{
 		storageRepo:      storageRepo,
@@ -196,23 +197,14 @@ func (s *IndexerService) ValidateTransactionData(transaction *contracts.LFXTrans
 		return err
 	}
 
-	// Decode the data if it is base64 encoded
-	if data, ok := transaction.Data.(string); ok {
-		decodedData, err := base64.StdEncoding.DecodeString(data)
-		if err == nil {
-			// If there is no error, then we can unmarshal the data.
-			// Otherwise, it means the data wasn't base64 encoded and therefore
-			// we can just use the data as is.
-			var data map[string]any
-			if err := json.Unmarshal(decodedData, &data); err != nil {
-				logging.LogError(logger, "Failed to unmarshal JSON", err,
-					"validation_step", "json_unmarshal",
-					"transaction_data", transaction.Data,
-					"transaction_id", transactionID)
-				return err
-			}
-			transaction.Data = data
-		}
+	// Try to decode the data
+	if err := s.decodeTransactionData(transaction); err != nil {
+		logging.LogError(logger, "Transaction data validation failed: failed to decode data", err,
+			"transaction_id", transactionID,
+			"validation_step", "data_decode",
+			"action", transaction.Action,
+			"object_type", transaction.ObjectType)
+		return err
 	}
 
 	switch {
@@ -249,6 +241,37 @@ func (s *IndexerService) ValidateTransactionData(transaction *contracts.LFXTrans
 
 	logger.Debug("Transaction data validation completed successfully",
 		"transaction_id", transactionID)
+	return nil
+}
+
+// decodeTransactionData decodes the transaction data
+func (s *IndexerService) decodeTransactionData(transaction *contracts.LFXTransaction) error {
+	logger := s.logger
+	transactionID := s.generateTransactionID(transaction)
+
+	// Decode the data if it is base64 encoded
+	if data, ok := transaction.Data.(string); ok {
+		decodedData, err := base64.StdEncoding.DecodeString(data)
+		if err == nil {
+			// If there is no error, then we can unmarshal the data.
+			// Otherwise, it means the data wasn't base64 encoded and therefore
+			// we can just use the data as is.
+			switch {
+			case s.isCreateAction(transaction) || s.isUpdateAction(transaction):
+				var data map[string]any
+				if err := json.Unmarshal(decodedData, &data); err != nil {
+					logging.LogError(logger, "Failed to unmarshal JSON", err,
+						"validation_step", "json_unmarshal",
+						"transaction_data", transaction.Data,
+						"transaction_id", transactionID)
+					return err
+				}
+				transaction.Data = data
+			case s.isDeleteAction(transaction):
+				transaction.Data = string(decodedData)
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -206,7 +205,10 @@ func (s *IndexerService) ValidateTransactionData(transaction *contracts.LFXTrans
 			// we can just use the data as is.
 			var data map[string]any
 			if err := json.Unmarshal(decodedData, &data); err != nil {
-				log.Printf("Failed to unmarshal JSON: %v", err)
+				logging.LogError(logger, "Failed to unmarshal JSON", err,
+					"validation_step", "json_unmarshal",
+					"transaction_data", transaction.Data,
+					"transaction_id", transactionID)
 				return err
 			}
 			transaction.Data = data

--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -7,8 +7,10 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -195,6 +197,22 @@ func (s *IndexerService) ValidateTransactionData(transaction *contracts.LFXTrans
 		return err
 	}
 
+	// Decode the data if it is base64 encoded
+	if data, ok := transaction.Data.(string); ok {
+		decodedData, err := base64.StdEncoding.DecodeString(data)
+		if err == nil {
+			// If there is no error, then we can unmarshal the data.
+			// Otherwise, it means the data wasn't base64 encoded and therefore
+			// we can just use the data as is.
+			var data map[string]any
+			if err := json.Unmarshal(decodedData, &data); err != nil {
+				log.Printf("Failed to unmarshal JSON: %v", err)
+				return err
+			}
+			transaction.Data = data
+		}
+	}
+
 	switch {
 	case s.isCreateAction(transaction) || s.isUpdateAction(transaction):
 		if _, ok := transaction.Data.(map[string]any); !ok {
@@ -204,6 +222,7 @@ func (s *IndexerService) ValidateTransactionData(transaction *contracts.LFXTrans
 				"validation_step", "data_type",
 				"action", transaction.Action,
 				"object_type", transaction.ObjectType,
+				"transaction_data", transaction.Data,
 				"expected_type", "object")
 			return err
 		}

--- a/internal/enrichers/project_enricher.go
+++ b/internal/enrichers/project_enricher.go
@@ -6,6 +6,7 @@ package enrichers
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/linuxfoundation/lfx-indexer-service/internal/domain/contracts"
@@ -81,11 +82,6 @@ func (e *ProjectEnricher) EnrichData(body *contracts.TransactionBody, transactio
 	}
 
 	// Handle parent project reference (enhanced requirement)
-	if parentID, ok := data["parentID"].(string); ok && parentID != "" {
-		body.ParentRefs = []string{parentID}
-	}
-
-	// Also handle legacy parent_uid field for backwards compatibility
 	if parentUID, ok := data["parent_uid"].(string); ok && parentUID != "" {
 		// If we already have ParentRefs from parentID, append to it
 		if body.ParentRefs == nil {
@@ -93,6 +89,11 @@ func (e *ProjectEnricher) EnrichData(body *contracts.TransactionBody, transactio
 		} else {
 			body.ParentRefs = append(body.ParentRefs, "project:"+parentUID)
 		}
+	}
+
+	// Also handle legacy parent_uid field for backwards compatibility
+	if parentID, ok := data["parentID"].(string); ok && parentID != "" {
+		body.ParentRefs = []string{parentID}
 	}
 
 	// Extract project name for sorting
@@ -122,7 +123,7 @@ func (e *ProjectEnricher) EnrichData(body *contracts.TransactionBody, transactio
 		}
 	}
 	// Include description if not already in fulltext
-	if body.Fulltext != "" && !contains(fulltext, body.Fulltext) {
+	if body.Fulltext != "" && !slices.Contains(fulltext, body.Fulltext) {
 		fulltext = append(fulltext, body.Fulltext)
 	}
 
@@ -132,14 +133,4 @@ func (e *ProjectEnricher) EnrichData(body *contracts.TransactionBody, transactio
 	}
 
 	return nil
-}
-
-// Helper function to check if slice contains string
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/enrichers/project_enricher.go
+++ b/internal/enrichers/project_enricher.go
@@ -83,17 +83,17 @@ func (e *ProjectEnricher) EnrichData(body *contracts.TransactionBody, transactio
 
 	// Handle parent project reference (enhanced requirement)
 	if parentUID, ok := data["parent_uid"].(string); ok && parentUID != "" {
-		// If we already have ParentRefs from parentID, append to it
-		if body.ParentRefs == nil {
-			body.ParentRefs = []string{"project:" + parentUID}
-		} else {
-			body.ParentRefs = append(body.ParentRefs, "project:"+parentUID)
-		}
+		body.ParentRefs = []string{"project:" + parentUID}
 	}
 
-	// Also handle legacy parent_uid field for backwards compatibility
+	// Also handle legacy parentID field for backwards compatibility
 	if parentID, ok := data["parentID"].(string); ok && parentID != "" {
-		body.ParentRefs = []string{parentID}
+		// If we already have ParentRefs from parent_uid, append to it
+		if body.ParentRefs == nil {
+			body.ParentRefs = []string{"project:" + parentID}
+		} else {
+			body.ParentRefs = append(body.ParentRefs, "project:"+parentID)
+		}
 	}
 
 	// Extract project name for sorting

--- a/internal/enrichers/project_settings_enricher.go
+++ b/internal/enrichers/project_settings_enricher.go
@@ -1,0 +1,79 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package enrichers provides data enrichment functionality for different object types.
+package enrichers
+
+import (
+	"fmt"
+
+	"github.com/linuxfoundation/lfx-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-indexer-service/pkg/constants"
+)
+
+// ProjectSettingsEnricher handles project-settings-specific enrichment logic
+type ProjectSettingsEnricher struct{}
+
+// NewProjectSettingsEnricher creates a new project settings enricher
+func NewProjectSettingsEnricher() *ProjectSettingsEnricher {
+	return &ProjectSettingsEnricher{}
+}
+
+// ObjectType returns the object type this enricher handles
+func (e *ProjectSettingsEnricher) ObjectType() string {
+	return constants.ObjectTypeProjectSettings
+}
+
+// EnrichData enriches project-specific data
+func (e *ProjectSettingsEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
+	data := transaction.ParsedData
+
+	// Set the processed data on the body (enricher owns data assignment)
+	body.Data = data
+
+	// Extract project ID using 'uid' field (matches reference implementation)
+	// Also support 'id' for backwards compatibility
+	var objectID string
+	if uid, ok := data["uid"].(string); ok {
+		objectID = uid
+	} else if id, ok := data["id"].(string); ok {
+		objectID = id
+	} else {
+		return fmt.Errorf("%s: missing or invalid project ID", constants.ErrMappingUID)
+	}
+	body.ObjectID = objectID
+
+	// A project's settings are not public for any project status
+	body.Public = false
+
+	// Set access control with reference implementation logic (computed defaults)
+	// Only apply defaults when fields are completely missing from data
+	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
+		// Field exists in data (even if empty) - use data value
+		body.AccessCheckObject = accessCheckObject
+	} else if _, exists := data["accessCheckObject"]; !exists {
+		// Field doesn't exist in data - use computed default
+		body.AccessCheckObject = fmt.Sprintf("project:%s", objectID)
+	}
+	// If field exists but is not a string, leave empty (no override)
+
+	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
+		body.AccessCheckRelation = accessCheckRelation
+	} else if _, exists := data["accessCheckRelation"]; !exists {
+		body.AccessCheckRelation = "viewer"
+	}
+
+	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
+		body.HistoryCheckObject = historyCheckObject
+	} else if _, exists := data["historyCheckObject"]; !exists {
+		body.HistoryCheckObject = fmt.Sprintf("project:%s", objectID)
+	}
+
+	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {
+		body.HistoryCheckRelation = historyCheckRelation
+	} else if _, exists := data["historyCheckRelation"]; !exists {
+		body.HistoryCheckRelation = "writer"
+	}
+
+	return nil
+}

--- a/internal/enrichers/project_settings_enricher_test.go
+++ b/internal/enrichers/project_settings_enricher_test.go
@@ -12,8 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProjectEnricher_EnrichData(t *testing.T) {
-	enricher := &ProjectEnricher{}
+func TestProjectSettingsEnricher_ObjectType(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
+	assert.Equal(t, constants.ObjectTypeProjectSettings, enricher.ObjectType())
+}
+
+func TestProjectSettingsEnricher_EnrichData(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
 
 	tests := []struct {
 		name           string
@@ -25,24 +30,22 @@ func TestProjectEnricher_EnrichData(t *testing.T) {
 		{
 			name: "successful enrichment with uid field",
 			parsedData: map[string]any{
-				"uid":    "project-123",
-				"public": true,
+				"uid": "project-123",
 			},
 			expectedBody: &contracts.TransactionBody{
 				ObjectID: "project-123",
-				Public:   true,
+				Public:   false, // Always false for project settings
 			},
 			expectedFields: []string{"ObjectID", "Public"},
 		},
 		{
 			name: "successful enrichment with legacy id field",
 			parsedData: map[string]any{
-				"id":     "project-456",
-				"public": false,
+				"id": "project-456",
 			},
 			expectedBody: &contracts.TransactionBody{
 				ObjectID: "project-456",
-				Public:   false,
+				Public:   false, // Always false for project settings
 			},
 			expectedFields: []string{"ObjectID", "Public"},
 		},
@@ -50,31 +53,29 @@ func TestProjectEnricher_EnrichData(t *testing.T) {
 			name: "successful enrichment with access control attributes",
 			parsedData: map[string]any{
 				"uid":                  "project-789",
-				"public":               true,
-				"accessCheckObject":    "project",
-				"accessCheckRelation":  "member",
-				"historyCheckObject":   "project",
-				"historyCheckRelation": "viewer",
+				"accessCheckObject":    "custom-object",
+				"accessCheckRelation":  "admin",
+				"historyCheckObject":   "custom-history",
+				"historyCheckRelation": "member",
 			},
 			expectedBody: &contracts.TransactionBody{
 				ObjectID:             "project-789",
-				Public:               true,
-				AccessCheckObject:    "project", // Override from data
-				AccessCheckRelation:  "member",  // Override from data
-				HistoryCheckObject:   "project", // Override from data
-				HistoryCheckRelation: "viewer",  // Override from data
+				Public:               false,
+				AccessCheckObject:    "custom-object",  // Override from data
+				AccessCheckRelation:  "admin",          // Override from data
+				HistoryCheckObject:   "custom-history", // Override from data
+				HistoryCheckRelation: "member",         // Override from data
 			},
 			expectedFields: []string{"ObjectID", "Public", "AccessCheckObject", "AccessCheckRelation", "HistoryCheckObject", "HistoryCheckRelation"},
 		},
 		{
 			name: "access control with computed defaults",
 			parsedData: map[string]any{
-				"uid":    "project-defaults",
-				"public": true,
+				"uid": "project-defaults",
 			},
 			expectedBody: &contracts.TransactionBody{
 				ObjectID:             "project-defaults",
-				Public:               true,
+				Public:               false,
 				AccessCheckObject:    "project:project-defaults", // Computed default
 				AccessCheckRelation:  "viewer",                   // Computed default
 				HistoryCheckObject:   "project:project-defaults", // Computed default
@@ -83,43 +84,17 @@ func TestProjectEnricher_EnrichData(t *testing.T) {
 			expectedFields: []string{"ObjectID", "Public", "AccessCheckObject", "AccessCheckRelation", "HistoryCheckObject", "HistoryCheckRelation"},
 		},
 		{
-			name: "successful enrichment with parent reference",
-			parsedData: map[string]any{
-				"uid":      "project-child",
-				"public":   true,
-				"parentID": "project-parent",
-			},
-			expectedBody: &contracts.TransactionBody{
-				ObjectID:   "project-child",
-				Public:     true,
-				ParentRefs: []string{"project:project-parent"},
-			},
-			expectedFields: []string{"ObjectID", "Public", "ParentRefs"},
-		},
-		{
-			name: "successful enrichment with empty parent reference",
-			parsedData: map[string]any{
-				"uid":      "project-orphan",
-				"public":   true,
-				"parentID": "",
-			},
-			expectedBody: &contracts.TransactionBody{
-				ObjectID:   "project-orphan",
-				Public:     true,
-				ParentRefs: nil,
-			},
-			expectedFields: []string{"ObjectID", "Public"},
-		},
-		{
-			name: "complete enrichment with all fields",
+			name: "complete enrichment with all fields and settings data",
 			parsedData: map[string]any{
 				"uid":                  "project-complete",
-				"public":               false,
 				"accessCheckObject":    "organization",
 				"accessCheckRelation":  "admin",
 				"historyCheckObject":   "organization",
-				"historyCheckRelation": "member",
-				"parentID":             "org-parent",
+				"historyCheckRelation": "admin",
+				"settings": map[string]any{
+					"feature_enabled": true,
+					"config_value":    "production",
+				},
 			},
 			expectedBody: &contracts.TransactionBody{
 				ObjectID:             "project-complete",
@@ -127,72 +102,52 @@ func TestProjectEnricher_EnrichData(t *testing.T) {
 				AccessCheckObject:    "organization",
 				AccessCheckRelation:  "admin",
 				HistoryCheckObject:   "organization",
-				HistoryCheckRelation: "member",
-				ParentRefs:           []string{"project:org-parent"},
+				HistoryCheckRelation: "admin",
 			},
-			expectedFields: []string{"ObjectID", "Public", "AccessCheckObject", "AccessCheckRelation", "HistoryCheckObject", "HistoryCheckRelation", "ParentRefs"},
+			expectedFields: []string{"ObjectID", "Public", "AccessCheckObject", "AccessCheckRelation", "HistoryCheckObject", "HistoryCheckRelation"},
 		},
 		{
-			name: "complete enrichment with search fields",
+			name: "project settings with configuration data",
 			parsedData: map[string]any{
-				"uid":         "project-search",
-				"public":      true,
-				"name":        "Example Project",
-				"slug":        "example-project",
-				"description": "A sample project for testing search functionality",
+				"uid": "project-config",
+				"configuration": map[string]any{
+					"notifications_enabled": false,
+					"email_frequency":       "weekly",
+					"privacy_settings": map[string]any{
+						"show_contributors": true,
+					},
+				},
 			},
 			expectedBody: &contracts.TransactionBody{
-				ObjectID:       "project-search",
-				Public:         true,
-				SortName:       "Example Project",
-				NameAndAliases: []string{"Example Project", "example-project"},
-				Fulltext:       "Example Project example-project A sample project for testing search functionality",
+				ObjectID:             "project-config",
+				Public:               false,
+				AccessCheckObject:    "project:project-config",
+				AccessCheckRelation:  "viewer",
+				HistoryCheckObject:   "project:project-config",
+				HistoryCheckRelation: "writer",
 			},
-			expectedFields: []string{"ObjectID", "Public", "SortName", "NameAndAliases", "Fulltext"},
-		},
-		{
-			name: "parent reference with legacy field",
-			parsedData: map[string]any{
-				"uid":        "project-child-legacy",
-				"public":     false,
-				"parent_uid": "parent-legacy",
-			},
-			expectedBody: &contracts.TransactionBody{
-				ObjectID:   "project-child-legacy",
-				Public:     false,
-				ParentRefs: []string{"project:parent-legacy"},
-			},
-			expectedFields: []string{"ObjectID", "Public", "ParentRefs"},
+			expectedFields: []string{"ObjectID", "Public", "AccessCheckObject", "AccessCheckRelation", "HistoryCheckObject", "HistoryCheckRelation"},
 		},
 		{
 			name: "error: missing uid and id",
 			parsedData: map[string]any{
-				"public": true,
+				"settings": map[string]any{"enabled": true},
 			},
 			expectedError: constants.ErrMappingUID,
 		},
 		{
 			name: "error: invalid uid type",
 			parsedData: map[string]any{
-				"uid":    123,
-				"public": true,
+				"uid": 123,
 			},
 			expectedError: constants.ErrMappingUID,
 		},
 		{
-			name: "error: missing public field",
+			name: "error: invalid id type",
 			parsedData: map[string]any{
-				"uid": "project-missing-public",
+				"id": false,
 			},
-			expectedError: constants.ErrMappingPublic,
-		},
-		{
-			name: "error: invalid public type",
-			parsedData: map[string]any{
-				"uid":    "project-invalid-public",
-				"public": "not-a-boolean",
-			},
-			expectedError: constants.ErrMappingPublic,
+			expectedError: constants.ErrMappingUID,
 		},
 	}
 
@@ -213,6 +168,9 @@ func TestProjectEnricher_EnrichData(t *testing.T) {
 
 			require.NoError(t, err)
 
+			// Verify that data is set on body
+			assert.Equal(t, tt.parsedData, body.Data, "Data should be set on body")
+
 			// Verify specified fields
 			for _, field := range tt.expectedFields {
 				switch field {
@@ -228,29 +186,20 @@ func TestProjectEnricher_EnrichData(t *testing.T) {
 					assert.Equal(t, tt.expectedBody.HistoryCheckObject, body.HistoryCheckObject, "HistoryCheckObject mismatch")
 				case "HistoryCheckRelation":
 					assert.Equal(t, tt.expectedBody.HistoryCheckRelation, body.HistoryCheckRelation, "HistoryCheckRelation mismatch")
-				case "ParentRefs":
-					assert.Equal(t, tt.expectedBody.ParentRefs, body.ParentRefs, "ParentRefs mismatch")
-				case "SortName":
-					assert.Equal(t, tt.expectedBody.SortName, body.SortName, "SortName mismatch")
-				case "NameAndAliases":
-					assert.Equal(t, tt.expectedBody.NameAndAliases, body.NameAndAliases, "NameAndAliases mismatch")
-				case "Fulltext":
-					assert.Equal(t, tt.expectedBody.Fulltext, body.Fulltext, "Fulltext mismatch")
 				}
 			}
 		})
 	}
 }
 
-func TestProjectEnricher_EnrichData_AccessControlComputedDefaults(t *testing.T) {
-	enricher := &ProjectEnricher{}
+func TestProjectSettingsEnricher_EnrichData_AccessControlComputedDefaults(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
 	body := &contracts.TransactionBody{}
 
 	// Test that access control fields get computed defaults when not provided
 	transaction := &contracts.LFXTransaction{
 		ParsedData: map[string]any{
-			"uid":    "project-computed-defaults",
-			"public": true,
+			"uid": "project-computed-defaults",
 		},
 	}
 
@@ -258,44 +207,42 @@ func TestProjectEnricher_EnrichData_AccessControlComputedDefaults(t *testing.T) 
 	require.NoError(t, err)
 
 	assert.Equal(t, "project-computed-defaults", body.ObjectID)
-	assert.True(t, body.Public)
+	assert.False(t, body.Public) // Always false for project settings
 	assert.Equal(t, "project:project-computed-defaults", body.AccessCheckObject)
 	assert.Equal(t, "viewer", body.AccessCheckRelation)
 	assert.Equal(t, "project:project-computed-defaults", body.HistoryCheckObject)
 	assert.Equal(t, "writer", body.HistoryCheckRelation)
 }
 
-func TestProjectEnricher_EnrichData_ParentReferenceOptional(t *testing.T) {
-	enricher := &ProjectEnricher{}
+func TestProjectSettingsEnricher_EnrichData_AlwaysPrivate(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
 	body := &contracts.TransactionBody{}
 
-	// Test that parent reference is optional
+	// Test that project settings are always private, regardless of input
 	transaction := &contracts.LFXTransaction{
 		ParsedData: map[string]any{
-			"uid":    "project-no-parent",
-			"public": false,
+			"uid":    "project-privacy-test",
+			"public": true, // This should be ignored
 		},
 	}
 
 	err := enricher.EnrichData(body, transaction)
 	require.NoError(t, err)
 
-	assert.Equal(t, "project-no-parent", body.ObjectID)
-	assert.False(t, body.Public)
-	assert.Nil(t, body.ParentRefs)
+	assert.Equal(t, "project-privacy-test", body.ObjectID)
+	assert.False(t, body.Public, "Project settings should always be private")
 }
 
-func TestProjectEnricher_EnrichData_BackwardsCompatibility(t *testing.T) {
-	enricher := &ProjectEnricher{}
+func TestProjectSettingsEnricher_EnrichData_BackwardsCompatibility(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
 
 	// Test that both 'uid' and 'id' fields work, with 'uid' taking precedence
 	t.Run("uid takes precedence over id", func(t *testing.T) {
 		body := &contracts.TransactionBody{}
 		transaction := &contracts.LFXTransaction{
 			ParsedData: map[string]any{
-				"uid":    "project-uid",
-				"id":     "project-id",
-				"public": true,
+				"uid": "project-uid",
+				"id":  "project-id",
 			},
 		}
 
@@ -308,8 +255,7 @@ func TestProjectEnricher_EnrichData_BackwardsCompatibility(t *testing.T) {
 		body := &contracts.TransactionBody{}
 		transaction := &contracts.LFXTransaction{
 			ParsedData: map[string]any{
-				"id":     "project-legacy",
-				"public": true,
+				"id": "project-legacy",
 			},
 		}
 
@@ -319,15 +265,14 @@ func TestProjectEnricher_EnrichData_BackwardsCompatibility(t *testing.T) {
 	})
 }
 
-func TestProjectEnricher_EnrichData_EdgeCases(t *testing.T) {
-	enricher := &ProjectEnricher{}
+func TestProjectSettingsEnricher_EnrichData_EdgeCases(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
 
 	t.Run("empty string values for access control", func(t *testing.T) {
 		body := &contracts.TransactionBody{}
 		transaction := &contracts.LFXTransaction{
 			ParsedData: map[string]any{
 				"uid":                  "project-empty-strings",
-				"public":               true,
 				"accessCheckObject":    "",
 				"accessCheckRelation":  "",
 				"historyCheckObject":   "",
@@ -350,7 +295,6 @@ func TestProjectEnricher_EnrichData_EdgeCases(t *testing.T) {
 		transaction := &contracts.LFXTransaction{
 			ParsedData: map[string]any{
 				"uid":                  "project-non-string",
-				"public":               true,
 				"accessCheckObject":    123,
 				"accessCheckRelation":  false,
 				"historyCheckObject":   nil,
@@ -361,27 +305,84 @@ func TestProjectEnricher_EnrichData_EdgeCases(t *testing.T) {
 		err := enricher.EnrichData(body, transaction)
 		require.NoError(t, err)
 
-		// Non-string values should be ignored (not set)
-		assert.Empty(t, body.AccessCheckObject)
-		assert.Empty(t, body.AccessCheckRelation)
-		assert.Empty(t, body.HistoryCheckObject)
-		assert.Empty(t, body.HistoryCheckRelation)
+		// Non-string values should be ignored (left empty, no override)
+		assert.Equal(t, "", body.AccessCheckObject)
+		assert.Equal(t, "", body.AccessCheckRelation)
+		assert.Equal(t, "", body.HistoryCheckObject)
+		assert.Equal(t, "", body.HistoryCheckRelation)
 	})
 
-	t.Run("non-string parent ID ignored", func(t *testing.T) {
+	t.Run("complex settings data preserved", func(t *testing.T) {
+		body := &contracts.TransactionBody{}
+		complexData := map[string]any{
+			"uid": "project-complex",
+			"settings": map[string]any{
+				"notifications": map[string]any{
+					"email":  true,
+					"slack":  false,
+					"digest": "weekly",
+				},
+				"permissions": []string{"read", "write", "admin"},
+				"metadata": map[string]any{
+					"created_by": "admin@example.com",
+					"version":    "1.0.0",
+				},
+			},
+		}
+		transaction := &contracts.LFXTransaction{
+			ParsedData: complexData,
+		}
+
+		err := enricher.EnrichData(body, transaction)
+		require.NoError(t, err)
+
+		// Complex data should be preserved exactly
+		assert.Equal(t, complexData, body.Data, "Complex settings data should be preserved")
+		assert.Equal(t, "project-complex", body.ObjectID)
+		assert.False(t, body.Public)
+	})
+
+	t.Run("nil and missing fields handled correctly", func(t *testing.T) {
 		body := &contracts.TransactionBody{}
 		transaction := &contracts.LFXTransaction{
 			ParsedData: map[string]any{
-				"uid":      "project-non-string-parent",
-				"public":   true,
-				"parentID": 123,
+				"uid":              "project-minimal",
+				"some_other_field": nil,
 			},
 		}
 
 		err := enricher.EnrichData(body, transaction)
 		require.NoError(t, err)
 
-		// Non-string parent ID should be ignored
-		assert.Nil(t, body.ParentRefs)
+		assert.Equal(t, "project-minimal", body.ObjectID)
+		assert.False(t, body.Public)
+		// Should have computed defaults since access control fields don't exist
+		assert.Equal(t, "project:project-minimal", body.AccessCheckObject)
+		assert.Equal(t, "viewer", body.AccessCheckRelation)
+		assert.Equal(t, "project:project-minimal", body.HistoryCheckObject)
+		assert.Equal(t, "writer", body.HistoryCheckRelation)
 	})
+}
+
+func TestProjectSettingsEnricher_EnrichData_DataOwnership(t *testing.T) {
+	enricher := NewProjectSettingsEnricher()
+	body := &contracts.TransactionBody{}
+
+	originalData := map[string]any{
+		"uid": "project-data-test",
+		"settings": map[string]any{
+			"feature": "enabled",
+		},
+	}
+
+	transaction := &contracts.LFXTransaction{
+		ParsedData: originalData,
+	}
+
+	err := enricher.EnrichData(body, transaction)
+	require.NoError(t, err)
+
+	// Enricher should own the data assignment
+	assert.Equal(t, originalData, body.Data, "Enricher should set the data on the body")
+	assert.NotNil(t, body.Data, "Data should not be nil")
 }

--- a/internal/infrastructure/config/app_config.go
+++ b/internal/infrastructure/config/app_config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -280,12 +281,12 @@ func (c *AppConfig) validateJWT() error {
 // validateLogging validates logging configuration (PREVIOUSLY MISSING!)
 func (c *AppConfig) validateLogging() error {
 	validLevels := []string{"debug", "info", "warn", "error", "fatal", "panic"}
-	if !contains(validLevels, c.Logging.Level) {
+	if !slices.Contains(validLevels, c.Logging.Level) {
 		return fmt.Errorf("invalid log level: %s, must be one of: %v", c.Logging.Level, validLevels)
 	}
 
 	validFormats := []string{"json", "text", "console"}
-	if !contains(validFormats, c.Logging.Format) {
+	if !slices.Contains(validFormats, c.Logging.Format) {
 		return fmt.Errorf("invalid log format: %s, must be one of: %v", c.Logging.Format, validFormats)
 	}
 
@@ -379,14 +380,4 @@ func (c *AppConfig) validateHealth() error {
 	}
 
 	return nil
-}
-
-// Helper function for slice contains check
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -42,6 +42,7 @@ const (
 // Object types (centralized)
 const (
 	ObjectTypeProject         = "project"
+	ObjectTypeProjectSettings = "project_settings"
 	ObjectTypeCommittee       = "committee"
 	ObjectTypeCommitteeMember = "committeemember"
 )


### PR DESCRIPTION
Ticket: [LFXV2-11](https://linuxfoundation.atlassian.net/browse/LFXV2-11)

- Add project_settings data enricher for the new project_settings object type
- Use `slices` package instead of maintaining our own contains function
- Base64 decode data from the NATS message
- Update Makefile helm variables to match the helm chart
- Update helm chart opensearch URL to be consistent with other services
- Add a CLAUDE.md file
- Run markdownlint on README.md 

[LFXV2-11]: https://linuxfoundation.atlassian.net/browse/LFXV2-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ