### PR TITLE
Add past meeting enrichers - LFXV2-376

### DIFF
--- a/charts/lfx-v2-indexer-service/Chart.yaml
+++ b/charts/lfx-v2-indexer-service/Chart.yaml
@@ -6,5 +6,5 @@ apiVersion: v2
 name: lfx-v2-indexer-service
 description: LFX Platform V2 Indexer Service chart
 type: application
-version: 0.2.0
+version: 0.4.0
 appVersion: "latest"

--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -82,6 +82,8 @@ func NewIndexerService(
 		enrichers.NewMeetingEnricher(),
 		enrichers.NewMeetingSettingsEnricher(),
 		enrichers.NewMeetingRegistrantEnricher(),
+		enrichers.NewPastMeetingEnricher(),
+		enrichers.NewPastMeetingParticipantEnricher(),
 		enrichers.NewGroupsIOServiceEnricher(),
 	} {
 		registry.Register(enricher)

--- a/internal/enrichers/default_enricher_test.go
+++ b/internal/enrichers/default_enricher_test.go
@@ -316,7 +316,7 @@ func TestDefaultEnricher_EnrichData_SortName(t *testing.T) {
 		{
 			name: "falls back to display_name",
 			parsedData: map[string]any{
-				"uid":   "test-123",
+				"uid":          "test-123",
 				"display_name": "Display Name",
 				"label":        "Label Value",
 			},
@@ -333,7 +333,7 @@ func TestDefaultEnricher_EnrichData_SortName(t *testing.T) {
 		{
 			name: "returns empty when no name fields",
 			parsedData: map[string]any{
-				"uid": "test-123",
+				"uid":         "test-123",
 				"description": "Some description",
 			},
 			expectedSortName: "",

--- a/internal/enrichers/past_meeting_enricher.go
+++ b/internal/enrichers/past_meeting_enricher.go
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package enrichers provides data enrichment functionality for different object types.
+package enrichers
+
+import (
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+)
+
+// PastMeetingEnricher handles past meeting-specific enrichment logic
+type PastMeetingEnricher struct {
+	defaultEnricher Enricher
+}
+
+// ObjectType returns the object type this enricher handles.
+func (e *PastMeetingEnricher) ObjectType() string {
+	return e.defaultEnricher.ObjectType()
+}
+
+// EnrichData enriches past meeting-specific data
+func (e *PastMeetingEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
+	return e.defaultEnricher.EnrichData(body, transaction)
+}
+
+// extractPublicFlag extracts the public flag from the past meeting message data
+func (e *PastMeetingEnricher) extractPublicFlag(data map[string]any) bool {
+	visibility, ok := data["visibility"].(string)
+	if !ok {
+		return false
+	}
+	return visibility == "public"
+}
+
+// NewPastMeetingEnricher creates a new past meeting enricher
+func NewPastMeetingEnricher() Enricher {
+	enricher := &PastMeetingEnricher{}
+	enricher.defaultEnricher = newDefaultEnricher(
+		constants.ObjectTypePastMeeting,
+		WithPublicFlag(enricher.extractPublicFlag),
+	)
+	return enricher
+}

--- a/internal/enrichers/past_meeting_participant_enricher.go
+++ b/internal/enrichers/past_meeting_participant_enricher.go
@@ -13,45 +13,45 @@ import (
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
-// MeetingRegistrantEnricher handles meeting-registrant-specific enrichment logic
-type MeetingRegistrantEnricher struct {
+// PastMeetingParticipantEnricher handles past meeting participant-specific enrichment logic
+type PastMeetingParticipantEnricher struct {
 	defaultEnricher Enricher
 }
 
 // ObjectType returns the object type this enricher handles.
-func (e *MeetingRegistrantEnricher) ObjectType() string {
+func (e *PastMeetingParticipantEnricher) ObjectType() string {
 	return e.defaultEnricher.ObjectType()
 }
 
-// EnrichData enriches meeting-specific data
-func (e *MeetingRegistrantEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
+// EnrichData enriches past meeting participant-specific data
+func (e *PastMeetingParticipantEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
 	return e.defaultEnricher.EnrichData(body, transaction)
 }
 
-// setAccessControl provides meeting-registrant-specific access control logic
-func (e *MeetingRegistrantEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
-	// Set access control with meeting-registrant-specific logic
+// setAccessControl provides past meeting participant-specific access control logic
+func (e *PastMeetingParticipantEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
+	// Set access control with past meeting participant-specific logic
 	// Only apply defaults when fields are completely missing from data
 	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
 		// Field exists in data (even if empty) - use data value
 		body.AccessCheckObject = accessCheckObject
 	} else if _, exists := data["accessCheckObject"]; !exists {
 		// Field doesn't exist in data - use computed default with objectType prefix
-		body.AccessCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypeMeeting, objectID)
+		body.AccessCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, objectID)
 	}
 	// If field exists but is not a string, leave empty (no override)
 
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
 		body.AccessCheckRelation = accessCheckRelation
 	} else if _, exists := data["accessCheckRelation"]; !exists {
-		// TODO: should this be auditor from the project? How would we determine that from the meeting fga object?
+		// TODO: should this be auditor from the project? How would we determine that from the past meeting fga object?
 		body.AccessCheckRelation = "organizer"
 	}
 
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
 		body.HistoryCheckObject = historyCheckObject
 	} else if _, exists := data["historyCheckObject"]; !exists {
-		body.HistoryCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypeMeeting, objectID)
+		body.HistoryCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, objectID)
 	}
 
 	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {
@@ -61,8 +61,8 @@ func (e *MeetingRegistrantEnricher) setAccessControl(body *contracts.Transaction
 	}
 }
 
-// extractSortName extracts the sort name from the meeting message data
-func (e *MeetingRegistrantEnricher) extractSortName(data map[string]any) string {
+// extractSortName extracts the sort name from the past meeting participant message data
+func (e *PastMeetingParticipantEnricher) extractSortName(data map[string]any) string {
 	if value, ok := data["email"]; ok {
 		if strValue, isString := value.(string); isString && strValue != "" {
 			return strings.TrimSpace(strValue)
@@ -71,8 +71,8 @@ func (e *MeetingRegistrantEnricher) extractSortName(data map[string]any) string 
 	return ""
 }
 
-// extractNameAndAliases extracts the name and aliases from the meeting message data
-func (e *MeetingRegistrantEnricher) extractNameAndAliases(data map[string]any) []string {
+// extractNameAndAliases extracts the name and aliases from the past meeting participant message data
+func (e *PastMeetingParticipantEnricher) extractNameAndAliases(data map[string]any) []string {
 	var nameAndAliases []string
 	seen := make(map[string]bool) // Deduplicate names
 
@@ -95,11 +95,11 @@ func (e *MeetingRegistrantEnricher) extractNameAndAliases(data map[string]any) [
 	return nameAndAliases
 }
 
-// NewMeetingRegistrantEnricher creates a new meeting registrant enricher
-func NewMeetingRegistrantEnricher() Enricher {
-	enricher := &MeetingRegistrantEnricher{}
+// NewPastMeetingParticipantEnricher creates a new past meeting participant enricher
+func NewPastMeetingParticipantEnricher() Enricher {
+	enricher := &PastMeetingParticipantEnricher{}
 	enricher.defaultEnricher = newDefaultEnricher(
-		constants.ObjectTypeMeetingRegistrant,
+		constants.ObjectTypePastMeetingParticipant,
 		WithAccessControl(enricher.setAccessControl),
 		WithNameAndAliases(enricher.extractNameAndAliases),
 		WithSortName(enricher.extractSortName),

--- a/internal/enrichers/past_meeting_participant_enricher.go
+++ b/internal/enrichers/past_meeting_participant_enricher.go
@@ -30,6 +30,15 @@ func (e *PastMeetingParticipantEnricher) EnrichData(body *contracts.TransactionB
 
 // setAccessControl provides past meeting participant-specific access control logic
 func (e *PastMeetingParticipantEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
+	pastMeetingLevelPermission := func(data map[string]any) string {
+		if value, ok := data["past_meeting_uid"]; ok {
+			if pastMeetingUID, ok := value.(string); ok {
+				return fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, pastMeetingUID)
+			}
+		}
+		return fmt.Sprintf("%s:%s", objectType, objectID)
+	}
+
 	// Set access control with past meeting participant-specific logic
 	// Only apply defaults when fields are completely missing from data
 	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
@@ -37,7 +46,7 @@ func (e *PastMeetingParticipantEnricher) setAccessControl(body *contracts.Transa
 		body.AccessCheckObject = accessCheckObject
 	} else if _, exists := data["accessCheckObject"]; !exists {
 		// Field doesn't exist in data - use computed default with objectType prefix
-		body.AccessCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, objectID)
+		body.AccessCheckObject = pastMeetingLevelPermission(data)
 	}
 	// If field exists but is not a string, leave empty (no override)
 
@@ -51,7 +60,7 @@ func (e *PastMeetingParticipantEnricher) setAccessControl(body *contracts.Transa
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
 		body.HistoryCheckObject = historyCheckObject
 	} else if _, exists := data["historyCheckObject"]; !exists {
-		body.HistoryCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, objectID)
+		body.HistoryCheckObject = pastMeetingLevelPermission(data)
 	}
 
 	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -42,15 +42,17 @@ const (
 
 // Object types (centralized)
 const (
-	ObjectTypeProject           = "project"
-	ObjectTypeProjectSettings   = "project_settings"
-	ObjectTypeCommittee         = "committee"
-	ObjectTypeCommitteeSettings = "committee_settings"
-	ObjectTypeCommitteeMember   = "committeemember"
-	ObjectTypeMeeting           = "meeting"
-	ObjectTypeMeetingSettings   = "meeting_settings"
-	ObjectTypeMeetingRegistrant = "meeting_registrant"
-	ObjectTypeGroupsIOService   = "groupsio_service"
+	ObjectTypeProject                = "project"
+	ObjectTypeProjectSettings        = "project_settings"
+	ObjectTypeCommittee              = "committee"
+	ObjectTypeCommitteeSettings      = "committee_settings"
+	ObjectTypeCommitteeMember        = "committeemember"
+	ObjectTypeMeeting                = "meeting"
+	ObjectTypePastMeeting            = "past_meeting"
+	ObjectTypePastMeetingParticipant = "past_meeting_participant"
+	ObjectTypeMeetingSettings        = "meeting_settings"
+	ObjectTypeMeetingRegistrant      = "meeting_registrant"
+	ObjectTypeGroupsIOService        = "groupsio_service"
 )
 
 // Message processing constants


### PR DESCRIPTION
## Summary
- Add PastMeetingEnricher with visibility-based public flag logic for past meetings
- Add PastMeetingParticipantEnricher with custom access control and name handling for past meeting participants
- Register both new enrichers in IndexerService to enable data processing
- Update constants to include new object types: `ObjectTypePastMeeting` and `ObjectTypePastMeetingParticipant`

Related to: https://linuxfoundation.atlassian.net/browse/LFXV2-376

🤖 Generated with [Claude Code](https://claude.ai/code)