### PR TITLE
Add past meeting recording enricher - LFXV2-312

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -85,6 +85,7 @@ func NewIndexerService(
 		enrichers.NewMeetingRegistrantEnricher(),
 		enrichers.NewPastMeetingEnricher(),
 		enrichers.NewPastMeetingParticipantEnricher(),
+		enrichers.NewPastMeetingRecordingEnricher(),
 		enrichers.NewGroupsIOServiceEnricher(),
 		enrichers.NewGroupsIOMailingListEnricher(),
 	} {

--- a/internal/enrichers/past_meeting_recording_enricher.go
+++ b/internal/enrichers/past_meeting_recording_enricher.go
@@ -1,0 +1,66 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package enrichers provides data enrichment functionality for different object types.
+package enrichers
+
+import (
+	"fmt"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+)
+
+// PastMeetingRecordingEnricher handles past meeting recording-specific enrichment logic
+type PastMeetingRecordingEnricher struct {
+	defaultEnricher Enricher
+}
+
+// ObjectType returns the object type this enricher handles.
+func (e *PastMeetingRecordingEnricher) ObjectType() string {
+	return e.defaultEnricher.ObjectType()
+}
+
+// EnrichData enriches meeting-specific data
+func (e *PastMeetingRecordingEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
+	return e.defaultEnricher.EnrichData(body, transaction)
+}
+
+// setAccessControl provides meeting-settings-specific access control logic
+func (e *PastMeetingRecordingEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
+	// Set access control with past meeting recording-specific logic
+	// Only apply defaults when fields are completely missing from data
+	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
+		body.AccessCheckObject = accessCheckObject
+	} else if _, exists := data["accessCheckObject"]; !exists {
+		body.AccessCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, objectID)
+	}
+
+	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
+		body.AccessCheckRelation = accessCheckRelation
+	} else if _, exists := data["accessCheckRelation"]; !exists {
+		body.AccessCheckRelation = "viewer"
+	}
+
+	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
+		body.HistoryCheckObject = historyCheckObject
+	} else if _, exists := data["historyCheckObject"]; !exists {
+		body.HistoryCheckObject = fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, objectID)
+	}
+
+	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {
+		body.HistoryCheckRelation = historyCheckRelation
+	} else if _, exists := data["historyCheckRelation"]; !exists {
+		body.HistoryCheckRelation = "writer"
+	}
+}
+
+// NewPastMeetingRecordingEnricher creates a new past meeting recording enricher
+func NewPastMeetingRecordingEnricher() Enricher {
+	enricher := &PastMeetingRecordingEnricher{}
+	enricher.defaultEnricher = newDefaultEnricher(
+		constants.ObjectTypePastMeetingRecording,
+		WithAccessControl(enricher.setAccessControl),
+	)
+	return enricher
+}

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -52,6 +52,7 @@ const (
 	ObjectTypeMeetingRegistrant      = "meeting_registrant"
 	ObjectTypePastMeeting            = "past_meeting"
 	ObjectTypePastMeetingParticipant = "past_meeting_participant"
+	ObjectTypePastMeetingRecording   = "past_meeting_recording"
 	ObjectTypeGroupsIOService        = "groupsio_service"
 	ObjectTypeGroupsIOMailingList    = "groupsio_mailing_list"
 )


### PR DESCRIPTION
## Summary
- Add PastMeetingRecordingEnricher with custom access control logic that uses past meeting permissions
- Register the new enricher in IndexerService to enable processing of past meeting recording data
- Add ObjectTypePastMeetingRecording constant for the new object type

## Test plan
- [ ] Verify past meeting recording enricher is registered and functional
- [ ] Test custom access control logic for past meeting recordings
- [ ] Confirm new object type constant is properly defined and used

Related to: https://linuxfoundation.atlassian.net/browse/LFXV2-312

🤖 Generated with [Claude Code](https://claude.ai/code)