### PR TITLE
Adding GroupsIOMemberEnricher to the enricher registry in IndexerService

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -88,6 +88,7 @@ func NewIndexerService(
 		enrichers.NewPastMeetingRecordingEnricher(),
 		enrichers.NewGroupsIOServiceEnricher(),
 		enrichers.NewGroupsIOMailingListEnricher(),
+		enrichers.NewGroupsIOMemberEnricher(),
 	} {
 		registry.Register(enricher)
 	}

--- a/internal/enrichers/groupsio_member_enricher.go
+++ b/internal/enrichers/groupsio_member_enricher.go
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package enrichers provides data enrichment functionality for different object types.
+package enrichers
+
+import (
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+)
+
+// GroupsIOMemberEnricher handles GroupsIO member specific enrichment logic
+type GroupsIOMemberEnricher struct {
+	defaultEnricher Enricher
+}
+
+// ObjectType returns the object type this enricher handles.
+func (e *GroupsIOMemberEnricher) ObjectType() string {
+	return e.defaultEnricher.ObjectType()
+}
+
+// EnrichData enriches GroupsIO member specific data
+func (e *GroupsIOMemberEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
+	return e.defaultEnricher.EnrichData(body, transaction)
+}
+
+// NewGroupsIOMemberEnricher creates a new GroupsIO member enricher
+func NewGroupsIOMemberEnricher() Enricher {
+	return &GroupsIOMemberEnricher{
+		defaultEnricher: newDefaultEnricher(constants.ObjectTypeGroupsIOMember),
+	}
+}

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -55,6 +55,7 @@ const (
 	ObjectTypePastMeetingRecording   = "past_meeting_recording"
 	ObjectTypeGroupsIOService        = "groupsio_service"
 	ObjectTypeGroupsIOMailingList    = "groupsio_mailing_list"
+	ObjectTypeGroupsIOMember         = "groupsio_member"
 )
 
 // Message processing constants


### PR DESCRIPTION
Issue - https://linuxfoundation.atlassian.net/browse/LFXV2-352
This pull request introduces support for enriching GroupsIO member data in the indexer service. The main changes add a new enricher for GroupsIO members, register it with the service, and define the appropriate object type constant.

**GroupsIO Member Enrichment Support:**

* Added a new `GroupsIOMemberEnricher` in `internal/enrichers/groupsio_member_enricher.go` to handle enrichment logic for GroupsIO member objects, following the existing enricher pattern.
* Registered the new `GroupsIOMemberEnricher` in the indexer service initialization within `internal/domain/services/indexer_service.go`.
* Introduced a new constant `ObjectTypeGroupsIOMember` in `pkg/constants/messaging.go` to identify GroupsIO member objects.