### PR TITLE
Update access relation to auditor for meeting enrichers

### DIFF
--- a/internal/enrichers/meeting_registrant_enricher.go
+++ b/internal/enrichers/meeting_registrant_enricher.go
@@ -53,8 +53,7 @@ func (e *MeetingRegistrantEnricher) setAccessControl(body *contracts.Transaction
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
 		body.AccessCheckRelation = accessCheckRelation
 	} else if _, exists := data["accessCheckRelation"]; !exists {
-		// TODO: should this be auditor from the project? How would we determine that from the meeting fga object?
-		body.AccessCheckRelation = "organizer"
+		body.AccessCheckRelation = "auditor"
 	}
 
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {

--- a/internal/enrichers/meeting_settings_enricher.go
+++ b/internal/enrichers/meeting_settings_enricher.go
@@ -42,8 +42,7 @@ func (e *MeetingSettingsEnricher) setAccessControl(body *contracts.TransactionBo
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
 		body.AccessCheckRelation = accessCheckRelation
 	} else if _, exists := data["accessCheckRelation"]; !exists {
-		// TODO: should this be auditor from the project? How would we determine that from the meeting fga object?
-		body.AccessCheckRelation = "organizer"
+		body.AccessCheckRelation = "auditor"
 	}
 
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {

--- a/internal/enrichers/past_meeting_participant_enricher.go
+++ b/internal/enrichers/past_meeting_participant_enricher.go
@@ -53,8 +53,7 @@ func (e *PastMeetingParticipantEnricher) setAccessControl(body *contracts.Transa
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
 		body.AccessCheckRelation = accessCheckRelation
 	} else if _, exists := data["accessCheckRelation"]; !exists {
-		// TODO: should this be auditor from the project? How would we determine that from the past meeting fga object?
-		body.AccessCheckRelation = "organizer"
+		body.AccessCheckRelation = "auditor"
 	}
 
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {


### PR DESCRIPTION
## Summary
- Changed default `accessCheckRelation` from "organizer" to "auditor" for meeting-related enrichers
- Affects MeetingRegistrantEnricher, MeetingSettingsEnricher, and PastMeetingParticipantEnricher
- Aligns with the broader auditor-based permission model for meeting resources

🤖 Generated with [Claude Code](https://claude.ai/code)