### PR TITLE
Fix: Register PastMeetingSummaryEnricher in IndexerService

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -86,6 +86,7 @@ func NewIndexerService(
 		enrichers.NewPastMeetingEnricher(),
 		enrichers.NewPastMeetingParticipantEnricher(),
 		enrichers.NewPastMeetingRecordingEnricher(),
+		enrichers.NewPastMeetingSummaryEnricher(),
 		enrichers.NewGroupsIOServiceEnricher(),
 		enrichers.NewGroupsIOMailingListEnricher(),
 		enrichers.NewGroupsIOMemberEnricher(),


### PR DESCRIPTION
## Summary
- Register the PastMeetingSummaryEnricher in the IndexerService enricher registry
- Fixes missing enricher registration that would cause past meeting summary indexing to fail

## Problem
The PastMeetingSummaryEnricher was created but not registered in the IndexerService, which meant that past meeting summary messages would fail to be processed correctly.

## Solution
Added `enrichers.NewPastMeetingSummaryEnricher()` to the enricher list in `IndexerService.NewIndexerService()`.

Related to: LFXV2-477

🤖 Generated with [Claude Code](https://claude.ai/code)