### PR TITLE
Bump chart version to 0.4.4

### DIFF
--- a/charts/lfx-v2-indexer-service/Chart.yaml
+++ b/charts/lfx-v2-indexer-service/Chart.yaml
@@ -6,5 +6,5 @@ apiVersion: v2
 name: lfx-v2-indexer-service
 description: LFX Platform V2 Indexer Service chart
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "latest"


### PR DESCRIPTION
This pull request updates the chart version for the `lfx-v2-indexer-service`. The only change is a minor version bump in the Helm chart metadata.

* Incremented the `version` field from `0.4.3` to `0.4.4` in `charts/lfx-v2-indexer-service/Chart.yaml` to reflect a new release.