### PR TITLE
[LFXV2-631] Store past meeting artifacts as independent objects

### DIFF
--- a/charts/lfx-v2-indexer-service/Chart.yaml
+++ b/charts/lfx-v2-indexer-service/Chart.yaml
@@ -6,5 +6,5 @@ apiVersion: v2
 name: lfx-v2-indexer-service
 description: LFX Platform V2 Indexer Service chart
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "latest"

--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -86,6 +86,7 @@ func NewIndexerService(
 		enrichers.NewPastMeetingEnricher(),
 		enrichers.NewPastMeetingParticipantEnricher(),
 		enrichers.NewPastMeetingRecordingEnricher(),
+		enrichers.NewPastMeetingTranscriptEnricher(),
 		enrichers.NewPastMeetingSummaryEnricher(),
 		enrichers.NewGroupsIOServiceEnricher(),
 		enrichers.NewGroupsIOMailingListEnricher(),

--- a/internal/enrichers/past_meeting_recording_enricher.go
+++ b/internal/enrichers/past_meeting_recording_enricher.go
@@ -28,10 +28,10 @@ func (e *PastMeetingRecordingEnricher) EnrichData(body *contracts.TransactionBod
 
 // setAccessControl provides past meeting recording-specific access control logic
 func (e *PastMeetingRecordingEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
-	pastMeetingLevelPermission := func(data map[string]any) string {
-		if value, ok := data["past_meeting_uid"]; ok {
-			if pastMeetingUID, ok := value.(string); ok {
-				return fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, pastMeetingUID)
+	pastMeetingRecordingLevelPermission := func(data map[string]any) string {
+		if value, ok := data["past_meeting_recording_uid"]; ok {
+			if pastMeetingRecordingUID, ok := value.(string); ok {
+				return fmt.Sprintf("%s:%s", constants.ObjectTypePastMeetingRecording, pastMeetingRecordingUID)
 			}
 		}
 		return fmt.Sprintf("%s:%s", objectType, objectID)
@@ -46,7 +46,7 @@ func (e *PastMeetingRecordingEnricher) setAccessControl(body *contracts.Transact
 	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
 		accessObject = accessCheckObject
 	} else if _, exists := data["accessCheckObject"]; !exists {
-		accessObject = pastMeetingLevelPermission(data)
+		accessObject = pastMeetingRecordingLevelPermission(data)
 	}
 
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
@@ -58,7 +58,7 @@ func (e *PastMeetingRecordingEnricher) setAccessControl(body *contracts.Transact
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
 		historyObject = historyCheckObject
 	} else if _, exists := data["historyCheckObject"]; !exists {
-		historyObject = pastMeetingLevelPermission(data)
+		historyObject = pastMeetingRecordingLevelPermission(data)
 	}
 
 	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {

--- a/internal/enrichers/past_meeting_summary_enricher.go
+++ b/internal/enrichers/past_meeting_summary_enricher.go
@@ -28,10 +28,10 @@ func (e *PastMeetingSummaryEnricher) EnrichData(body *contracts.TransactionBody,
 
 // setAccessControl provides past meeting summary-specific access control logic
 func (e *PastMeetingSummaryEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
-	pastMeetingLevelPermission := func(data map[string]any) string {
-		if value, ok := data["past_meeting_uid"]; ok {
-			if pastMeetingUID, ok := value.(string); ok {
-				return fmt.Sprintf("%s:%s", constants.ObjectTypePastMeeting, pastMeetingUID)
+	pastMeetingSummaryLevelPermission := func(data map[string]any) string {
+		if value, ok := data["past_meeting_summary_uid"]; ok {
+			if pastMeetingSummaryUID, ok := value.(string); ok {
+				return fmt.Sprintf("%s:%s", constants.ObjectTypePastMeetingSummary, pastMeetingSummaryUID)
 			}
 		}
 		return fmt.Sprintf("%s:%s", objectType, objectID)
@@ -46,7 +46,7 @@ func (e *PastMeetingSummaryEnricher) setAccessControl(body *contracts.Transactio
 	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
 		accessObject = accessCheckObject
 	} else if _, exists := data["accessCheckObject"]; !exists {
-		accessObject = pastMeetingLevelPermission(data)
+		accessObject = pastMeetingSummaryLevelPermission(data)
 	}
 
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
@@ -58,7 +58,7 @@ func (e *PastMeetingSummaryEnricher) setAccessControl(body *contracts.Transactio
 	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
 		historyObject = historyCheckObject
 	} else if _, exists := data["historyCheckObject"]; !exists {
-		historyObject = pastMeetingLevelPermission(data)
+		historyObject = pastMeetingSummaryLevelPermission(data)
 	}
 
 	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {

--- a/internal/enrichers/past_meeting_transcript_enricher.go
+++ b/internal/enrichers/past_meeting_transcript_enricher.go
@@ -1,0 +1,93 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package enrichers provides data enrichment functionality for different object types.
+package enrichers
+
+import (
+	"fmt"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+)
+
+// PastMeetingTranscriptEnricher handles past meeting transcript-specific enrichment logic
+type PastMeetingTranscriptEnricher struct {
+	defaultEnricher Enricher
+}
+
+// ObjectType returns the object type this enricher handles.
+func (e *PastMeetingTranscriptEnricher) ObjectType() string {
+	return e.defaultEnricher.ObjectType()
+}
+
+// EnrichData enriches past meeting transcript-specific data
+func (e *PastMeetingTranscriptEnricher) EnrichData(body *contracts.TransactionBody, transaction *contracts.LFXTransaction) error {
+	return e.defaultEnricher.EnrichData(body, transaction)
+}
+
+// setAccessControl provides past meeting transcript-specific access control logic
+func (e *PastMeetingTranscriptEnricher) setAccessControl(body *contracts.TransactionBody, data map[string]any, objectType, objectID string) {
+	pastMeetingTranscriptLevelPermission := func(data map[string]any) string {
+		if value, ok := data["past_meeting_transcript_uid"]; ok {
+			if pastMeetingTranscriptUID, ok := value.(string); ok {
+				return fmt.Sprintf("%s:%s", constants.ObjectTypePastMeetingTranscript, pastMeetingTranscriptUID)
+			}
+		}
+		return fmt.Sprintf("%s:%s", objectType, objectID)
+	}
+
+	// Build access control values
+	var accessObject, accessRelation string
+	var historyObject, historyRelation string
+
+	// Set access control with past meeting transcript-specific logic
+	// Only apply defaults when fields are completely missing from data
+	if accessCheckObject, ok := data["accessCheckObject"].(string); ok {
+		accessObject = accessCheckObject
+	} else if _, exists := data["accessCheckObject"]; !exists {
+		accessObject = pastMeetingTranscriptLevelPermission(data)
+	}
+
+	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
+		accessRelation = accessCheckRelation
+	} else if _, exists := data["accessCheckRelation"]; !exists {
+		accessRelation = "viewer"
+	}
+
+	if historyCheckObject, ok := data["historyCheckObject"].(string); ok {
+		historyObject = historyCheckObject
+	} else if _, exists := data["historyCheckObject"]; !exists {
+		historyObject = pastMeetingTranscriptLevelPermission(data)
+	}
+
+	if historyCheckRelation, ok := data["historyCheckRelation"].(string); ok {
+		historyRelation = historyCheckRelation
+	} else if _, exists := data["historyCheckRelation"]; !exists {
+		historyRelation = "writer"
+	}
+
+	// Assign to body fields (deprecated fields)
+	body.AccessCheckObject = accessObject
+	body.AccessCheckRelation = accessRelation
+	body.HistoryCheckObject = historyObject
+	body.HistoryCheckRelation = historyRelation
+
+	// Build and assign the query strings
+	if accessObject != "" && accessRelation != "" {
+		body.AccessCheckQuery = contracts.JoinFgaQuery(accessObject, accessRelation)
+	}
+	if historyObject != "" && historyRelation != "" {
+		body.HistoryCheckQuery = contracts.JoinFgaQuery(historyObject, historyRelation)
+	}
+}
+
+// NewPastMeetingTranscriptEnricher creates a new past meeting transcript enricher
+func NewPastMeetingTranscriptEnricher() Enricher {
+	enricher := &PastMeetingTranscriptEnricher{}
+	enricher.defaultEnricher = newDefaultEnricher(
+		constants.ObjectTypePastMeetingTranscript,
+		WithAccessControl(enricher.setAccessControl),
+	)
+	return enricher
+}

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -53,6 +53,7 @@ const (
 	ObjectTypePastMeeting            = "past_meeting"
 	ObjectTypePastMeetingParticipant = "past_meeting_participant"
 	ObjectTypePastMeetingRecording   = "past_meeting_recording"
+	ObjectTypePastMeetingTranscript  = "past_meeting_transcript"
 	ObjectTypePastMeetingSummary     = "past_meeting_summary"
 	ObjectTypeGroupsIOService        = "groupsio_service"
 	ObjectTypeGroupsIOMailingList    = "groupsio_mailing_list"


### PR DESCRIPTION
## Summary

- Updated past meeting recording and summary enrichers to use object-specific permissions instead of inheriting from parent past meeting object
- Added new past meeting transcript enricher to store transcripts as separate objects
- Bumped Helm chart version to 0.4.5

## Changes

### Permission Model Updates
- **Recording Enricher**: Now uses `past_meeting_recording_uid` and `ObjectTypePastMeetingRecording` for access/history checks
- **Summary Enricher**: Now uses `past_meeting_summary_uid` and `ObjectTypePastMeetingSummary` for access/history checks
- **Transcript Enricher**: New enricher using `past_meeting_transcript_uid` and `ObjectTypePastMeetingTranscript`

### New Files
- `internal/enrichers/past_meeting_transcript_enricher.go` - New enricher for transcript objects

### Modified Files
- `internal/enrichers/past_meeting_recording_enricher.go` - Updated permission logic
- `internal/enrichers/past_meeting_summary_enricher.go` - Updated permission logic
- `internal/domain/services/indexer_service.go` - Registered transcript enricher
- `pkg/constants/messaging.go` - Added `ObjectTypePastMeetingTranscript` constant
- `charts/lfx-v2-indexer-service/Chart.yaml` - Version bump to 0.4.5

## Ticket

[LFXV2-631](https://linuxfoundation.atlassian.net/browse/LFXV2-631)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-614]: https://linuxfoundation.atlassian.net/browse/LFXV2-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LFXV2-631]: https://linuxfoundation.atlassian.net/browse/LFXV2-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ