### PR TITLE
[LFXV2-920] Committee member visibility - Conditional Relation

### DIFF
--- a/charts/lfx-v2-indexer-service/Chart.yaml
+++ b/charts/lfx-v2-indexer-service/Chart.yaml
@@ -6,5 +6,5 @@ apiVersion: v2
 name: lfx-v2-indexer-service
 description: LFX Platform V2 Indexer Service chart
 type: application
-version: 0.4.12
+version: 0.4.13
 appVersion: "latest"

--- a/internal/enrichers/committee_member_enricher.go
+++ b/internal/enrichers/committee_member_enricher.go
@@ -61,7 +61,7 @@ func (e *CommitteeMemberEnricher) setAccessControl(body *contracts.TransactionBo
 	if accessCheckRelation, ok := data["accessCheckRelation"].(string); ok {
 		accessRelation = accessCheckRelation
 	} else if _, exists := data["accessCheckRelation"]; !exists {
-		accessRelation = "viewer"
+		accessRelation = "basic_profile_viewer"
 	}
 
 	// History check object

--- a/internal/enrichers/committee_member_enricher_test.go
+++ b/internal/enrichers/committee_member_enricher_test.go
@@ -31,10 +31,10 @@ func TestCommitteeMemberEnricher_setAccessControl(t *testing.T) {
 			objectID:   "member-456",
 			expectedAccess: map[string]string{
 				"AccessCheckObject":    "committee:committee-123",
-				"AccessCheckRelation":  "viewer",
+				"AccessCheckRelation":  "basic_profile_viewer",
 				"HistoryCheckObject":   "committee:committee-123",
 				"HistoryCheckRelation": "writer",
-				"AccessCheckQuery":     "committee:committee-123#viewer",
+				"AccessCheckQuery":     "committee:committee-123#basic_profile_viewer",
 				"HistoryCheckQuery":    "committee:committee-123#writer",
 			},
 		},
@@ -47,10 +47,10 @@ func TestCommitteeMemberEnricher_setAccessControl(t *testing.T) {
 			objectID:   "member-456",
 			expectedAccess: map[string]string{
 				"AccessCheckObject":    "committee_member:member-456",
-				"AccessCheckRelation":  "viewer",
+				"AccessCheckRelation":  "basic_profile_viewer",
 				"HistoryCheckObject":   "committee_member:member-456",
 				"HistoryCheckRelation": "writer",
-				"AccessCheckQuery":     "committee_member:member-456#viewer",
+				"AccessCheckQuery":     "committee_member:member-456#basic_profile_viewer",
 				"HistoryCheckQuery":    "committee_member:member-456#writer",
 			},
 		},
@@ -64,10 +64,10 @@ func TestCommitteeMemberEnricher_setAccessControl(t *testing.T) {
 			objectID:   "member-456",
 			expectedAccess: map[string]string{
 				"AccessCheckObject":    "committee:",
-				"AccessCheckRelation":  "viewer",
+				"AccessCheckRelation":  "basic_profile_viewer",
 				"HistoryCheckObject":   "committee:",
 				"HistoryCheckRelation": "writer",
-				"AccessCheckQuery":     "committee:#viewer",
+				"AccessCheckQuery":     "committee:#basic_profile_viewer",
 				"HistoryCheckQuery":    "committee:#writer",
 			},
 		},
@@ -81,10 +81,10 @@ func TestCommitteeMemberEnricher_setAccessControl(t *testing.T) {
 			objectID:   "member-456",
 			expectedAccess: map[string]string{
 				"AccessCheckObject":    "committee_member:member-456",
-				"AccessCheckRelation":  "viewer",
+				"AccessCheckRelation":  "basic_profile_viewer",
 				"HistoryCheckObject":   "committee_member:member-456",
 				"HistoryCheckRelation": "writer",
-				"AccessCheckQuery":     "committee_member:member-456#viewer",
+				"AccessCheckQuery":     "committee_member:member-456#basic_profile_viewer",
 				"HistoryCheckQuery":    "committee_member:member-456#writer",
 			},
 		},
@@ -137,11 +137,11 @@ func TestCommitteeMemberEnricher_setAccessControl(t *testing.T) {
 			objectType: "committee_member",
 			objectID:   "member-999",
 			expectedAccess: map[string]string{
-				"AccessCheckObject":    "explicit:access",  // explicit
-				"AccessCheckRelation":  "viewer",           // default
-				"HistoryCheckObject":   "explicit:history", // explicit
-				"HistoryCheckRelation": "writer",           // default
-				"AccessCheckQuery":     "explicit:access#viewer",
+				"AccessCheckObject":    "explicit:access",      // explicit
+				"AccessCheckRelation":  "basic_profile_viewer", // default
+				"HistoryCheckObject":   "explicit:history",     // explicit
+				"HistoryCheckRelation": "writer",               // default
+				"AccessCheckQuery":     "explicit:access#basic_profile_viewer",
 				"HistoryCheckQuery":    "explicit:history#writer",
 			},
 		},
@@ -467,10 +467,10 @@ func TestCommitteeMemberEnricher_Integration_AccessControlWithCommitteeUID(t *te
 			},
 			expectedAccess: map[string]string{
 				"AccessCheckObject":    "committee:committee-456",
-				"AccessCheckRelation":  "viewer",
+				"AccessCheckRelation":  "basic_profile_viewer",
 				"HistoryCheckObject":   "committee:committee-456",
 				"HistoryCheckRelation": "writer",
-				"AccessCheckQuery":     "committee:committee-456#viewer",
+				"AccessCheckQuery":     "committee:committee-456#basic_profile_viewer",
 				"HistoryCheckQuery":    "committee:committee-456#writer",
 			},
 		},
@@ -483,10 +483,10 @@ func TestCommitteeMemberEnricher_Integration_AccessControlWithCommitteeUID(t *te
 			},
 			expectedAccess: map[string]string{
 				"AccessCheckObject":    "committee_member:member-789",
-				"AccessCheckRelation":  "viewer",
+				"AccessCheckRelation":  "basic_profile_viewer",
 				"HistoryCheckObject":   "committee_member:member-789",
 				"HistoryCheckRelation": "writer",
-				"AccessCheckQuery":     "committee_member:member-789#viewer",
+				"AccessCheckQuery":     "committee_member:member-789#basic_profile_viewer",
 				"HistoryCheckQuery":    "committee_member:member-789#writer",
 			},
 		},


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-920

This pull request updates the default access control relation for committee member enrichment logic. The default relation is changed from "viewer" to "basic_profile_viewer" to better reflect the intended access level. All related tests have been updated to match this new default.

Relates to
* https://github.com/linuxfoundation/lfx-v2-committee-service/pull/54 (test evidence in this PR)

### Important

This will require updating all committee-member objects in OpenSearch.