### PR TITLE
[LFXV2-1166] Add pod disruption budget support

### DIFF
--- a/charts/lfx-v2-indexer-service/templates/pdb.yaml
+++ b/charts/lfx-v2-indexer-service/templates/pdb.yaml
@@ -1,0 +1,20 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+{{- if .Values.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: lfx-v2-indexer-service
+  namespace: lfx
+spec:
+  selector:
+    matchLabels:
+      app: lfx-v2-indexer-service
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/lfx-v2-indexer-service/templates/pdb.yaml
+++ b/charts/lfx-v2-indexer-service/templates/pdb.yaml
@@ -1,8 +1,13 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- if and (hasKey .Values.podDisruptionBudget "minAvailable") (hasKey .Values.podDisruptionBudget "maxUnavailable") }}
+{{- $hasMin := hasKey .Values.podDisruptionBudget "minAvailable" }}
+{{- $hasMax := hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+{{- if and $hasMin $hasMax }}
   {{- fail "podDisruptionBudget: cannot set both minAvailable and maxUnavailable" }}
+{{- end }}
+{{- if not (or $hasMin $hasMax) }}
+  {{- fail "podDisruptionBudget: either minAvailable or maxUnavailable must be set" }}
 {{- end }}
 ---
 apiVersion: policy/v1
@@ -14,10 +19,10 @@ spec:
   selector:
     matchLabels:
       app: lfx-v2-indexer-service
-  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  {{- if $hasMin }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  {{- if $hasMax }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/charts/lfx-v2-indexer-service/templates/pdb.yaml
+++ b/charts/lfx-v2-indexer-service/templates/pdb.yaml
@@ -1,6 +1,9 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (hasKey .Values.podDisruptionBudget "minAvailable") (hasKey .Values.podDisruptionBudget "maxUnavailable") }}
+  {{- fail "podDisruptionBudget: cannot set both minAvailable and maxUnavailable" }}
+{{- end }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -11,10 +14,10 @@ spec:
   selector:
     matchLabels:
       app: lfx-v2-indexer-service
-  {{- with .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ . }}
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
 {{- end }}

--- a/charts/lfx-v2-indexer-service/values.yaml
+++ b/charts/lfx-v2-indexer-service/values.yaml
@@ -104,6 +104,8 @@ app:
     # (default: "tracecontext,baggage")
     propagators: "tracecontext,baggage,jaeger"
 
+# podDisruptionBudget configures a PodDisruptionBudget for the deployment.
+# Only one of minAvailable or maxUnavailable may be set (not both).
 podDisruptionBudget:
   enabled: false
   # minAvailable: 1

--- a/charts/lfx-v2-indexer-service/values.yaml
+++ b/charts/lfx-v2-indexer-service/values.yaml
@@ -104,6 +104,11 @@ app:
     # (default: "tracecontext,baggage")
     propagators: "tracecontext,baggage,jaeger"
 
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1
+  # maxUnavailable: 1
+
 # image is the configuration for the container image
 image:
   # repository is the container image repository


### PR DESCRIPTION
## Summary
- Add `podDisruptionBudget` values to Helm chart (disabled by default)
- Create PodDisruptionBudget template supporting `minAvailable` and `maxUnavailable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)