### PR TITLE
Add deployment annotation for Backstage ingestion

### DIFF
--- a/charts/lfx-v2-indexer-service/templates/deployment.yaml
+++ b/charts/lfx-v2-indexer-service/templates/deployment.yaml
@@ -7,6 +7,10 @@ kind: Deployment
 metadata:
   name: lfx-v2-indexer-service
   namespace: lfx
+  {{- with .Values.deployment.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.app.replicas }}
   selector:

--- a/charts/lfx-v2-indexer-service/templates/deployment.yaml
+++ b/charts/lfx-v2-indexer-service/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
   selector:
     matchLabels:
       app: lfx-v2-indexer-service
+      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -22,6 +23,7 @@ spec:
       {{- end }}
       labels:
         app: lfx-v2-indexer-service
+        app.kubernetes.io/name: {{ .Chart.Name }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lfx-v2-indexer-service/templates/deployment.yaml
+++ b/charts/lfx-v2-indexer-service/templates/deployment.yaml
@@ -7,10 +7,8 @@ kind: Deployment
 metadata:
   name: lfx-v2-indexer-service
   namespace: lfx
-  {{- with .Values.deployment.labels }}
   labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.app.replicas }}
   selector:

--- a/charts/lfx-v2-indexer-service/templates/deployment.yaml
+++ b/charts/lfx-v2-indexer-service/templates/deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app: lfx-v2-indexer-service
-      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/lfx-v2-indexer-service/values.yaml
+++ b/charts/lfx-v2-indexer-service/values.yaml
@@ -150,9 +150,3 @@ health:
 messaging:
   # queue is the NATS queue name
   queue: "lfx.indexer.queue"
-
-# deployment configures the Deployment object itself.
-deployment:
-  # labels are additional labels applied to the Deployment metadata.
-  labels:
-    app.kubernetes.io/name: "lfx-v2-indexer-service"

--- a/charts/lfx-v2-indexer-service/values.yaml
+++ b/charts/lfx-v2-indexer-service/values.yaml
@@ -150,3 +150,9 @@ health:
 messaging:
   # queue is the NATS queue name
   queue: "lfx.indexer.queue"
+
+# deployment configures the Deployment object itself.
+deployment:
+  # labels are additional labels applied to the Deployment metadata.
+  labels:
+    app.kubernetes.io/name: "lfx-v2-indexer-service"


### PR DESCRIPTION
Spotify Backstage can pull kubernetes data from components using deployment annotations. This service is missing the name annotation needed to discover it.