### PR TITLE
[LFXV2-1464] feat: reject documents with non-ASCII object_id in indexer

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -639,6 +639,23 @@ func (s *IndexerService) EnrichTransaction(ctx context.Context, transaction *con
 	return nil
 }
 
+// isValidObjectID returns true if id is a non-empty string containing only printable,
+// non-space ASCII characters (U+0021–U+007E).
+// Documents with binary or non-ASCII object_ids produce garbled index entries in OpenSearch
+// (corrupted _id values, no data payload). Go's range loop replaces invalid UTF-8 bytes with
+// U+FFFD (> 0x7E), so invalid UTF-8 is caught by the same check.
+func isValidObjectID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if r < 0x21 || r > 0x7E {
+			return false
+		}
+	}
+	return true
+}
+
 // GenerateTransactionBody creates a transaction body for indexing
 func (s *IndexerService) GenerateTransactionBody(ctx context.Context, transaction *contracts.LFXTransaction) (*contracts.TransactionBody, error) {
 	logger := logging.FromContext(ctx, s.logger)
@@ -683,6 +700,16 @@ func (s *IndexerService) GenerateTransactionBody(ctx context.Context, transactio
 	case constants.ActionDeleted:
 		body.DeletedAt = &transaction.Timestamp
 		s.setPrincipalFields(body, transaction.ParsedPrincipals, constants.ActionDeleted)
+
+		if !isValidObjectID(transaction.ParsedObjectID) {
+			err := fmt.Errorf("%s: %q", constants.ErrInvalidObjectID, transaction.ParsedObjectID)
+			logging.LogError(logger, constants.ErrInvalidObjectID, err,
+				"transaction_id", transactionID,
+				"object_type", transaction.ObjectType,
+				"action", canonicalAction)
+			return nil, err
+		}
+
 		body.ObjectID = transaction.ParsedObjectID
 		body.ObjectRef = transaction.ObjectType + ":" + transaction.ParsedObjectID
 
@@ -711,6 +738,15 @@ func (s *IndexerService) GenerateTransactionBody(ctx context.Context, transactio
 		return nil, fmt.Errorf("failed to enrich transaction data: %w", err)
 	}
 	logger.Debug("Transaction data enrichment completed", "transaction_id", transactionID)
+
+	if !isValidObjectID(body.ObjectID) {
+		err := fmt.Errorf("%s: %q", constants.ErrInvalidObjectID, body.ObjectID)
+		logging.LogError(logger, constants.ErrInvalidObjectID, err,
+			"transaction_id", transactionID,
+			"object_type", transaction.ObjectType,
+			"action", canonicalAction)
+		return nil, err
+	}
 
 	// Set object reference
 	body.ObjectRef = transaction.ObjectType + ":" + body.ObjectID

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -1318,3 +1318,84 @@ func TestIndexerService_ProcessTransaction_V1ActionCanonicalizedInEvent(t *testi
 	// Subject must use canonical past-tense "created", not raw "create"
 	assert.Equal(t, "lfx.project.created", mockMessagingRepo.PublishCalls[0].Subject)
 }
+
+func TestIsValidObjectID(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		valid bool
+	}{
+		// Valid IDs
+		{name: "uuid", id: "550e8400-e29b-41d4-a716-446655440000", valid: true},
+		{name: "numeric string", id: "123456789", valid: true},
+		{name: "alphanumeric slug", id: "my-project", valid: true},
+		{name: "printable ASCII symbols", id: "foo_bar.baz", valid: true},
+
+		// Invalid IDs
+		{name: "empty string", id: "", valid: false},
+		{name: "space character", id: "hello world", valid: false},
+		{name: "null byte", id: "\x00", valid: false},
+		{name: "control byte 0x01", id: "\x01abc", valid: false},
+		{name: "high byte 0x80", id: "\x80abc", valid: false},
+		{name: "non-ASCII unicode", id: "abc\u05cfdef", valid: false},
+		{name: "unicode replacement char", id: "\uFFFD", valid: false},
+		{name: "tab character", id: "abc\tdef", valid: false},
+		// Exact pattern from LFXV2-1464: Hebrew letter + high bytes
+		{name: "corrupted groupsio_member id", id: "\u05cfz\ufffd\ufffd|", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidObjectID(tt.id)
+			if got != tt.valid {
+				t.Errorf("isValidObjectID(%q) = %v, want %v", tt.id, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestIndexerService_GenerateTransactionBody_InvalidObjectID_Delete(t *testing.T) {
+	mockStorageRepo := mocks.NewMockStorageRepository()
+	mockMessagingRepo := mocks.NewMockMessagingRepository()
+	logger, _ := logging.TestLogger(t)
+	service := NewIndexerService(mockStorageRepo, mockMessagingRepo, logger)
+
+	transaction := &contracts.LFXTransaction{
+		Action:          constants.ActionDeleted,
+		ObjectType:      "groupsio_member",
+		Data:            "\u05cfz\ufffd\ufffd|", // binary/non-ASCII id from LFXV2-1464
+		ParsedObjectID:  "\u05cfz\ufffd\ufffd|",
+		Timestamp:       time.Now(),
+		ParsedPrincipals: []contracts.Principal{},
+	}
+
+	_, err := service.GenerateTransactionBody(context.Background(), transaction)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), constants.ErrInvalidObjectID)
+}
+
+func TestIndexerService_ProcessTransaction_InvalidObjectID_Delete(t *testing.T) {
+	mockStorageRepo := mocks.NewMockStorageRepository()
+	mockMessagingRepo := mocks.NewMockMessagingRepository()
+	logger, _ := logging.TestLogger(t)
+	service := NewIndexerService(mockStorageRepo, mockMessagingRepo, logger)
+
+	transaction := &contracts.LFXTransaction{
+		Action:          constants.ActionDeleted,
+		ObjectType:      "groupsio_member",
+		Data:            "\u05cfz\ufffd|",
+		ParsedObjectID:  "\u05cfz\ufffd|",
+		Timestamp:       time.Now(),
+		Headers:         map[string]string{"authorization": "Bearer token"},
+		ParsedPrincipals: []contracts.Principal{},
+	}
+
+	result, err := service.ProcessTransaction(context.Background(), transaction, "test-index")
+
+	assert.Error(t, err)
+	assert.NotNil(t, result)
+	assert.False(t, result.Success)
+	assert.Contains(t, err.Error(), constants.ErrInvalidObjectID)
+	assert.Len(t, mockStorageRepo.IndexCalls, 0) // Must not write to OpenSearch
+}

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -30,6 +30,7 @@ const (
 	ErrEnrichmentFailed  = "transaction enrichment failed"
 	ErrMissingObjectID   = "missing or invalid object ID"
 	ErrMissingPublicFlag = "missing or invalid public flag"
+	ErrInvalidObjectID   = "object_id contains non-ASCII or non-printable characters"
 
 	// Storage specific errors
 	ErrMarshalQuery       = "failed to marshal query"


### PR DESCRIPTION
## Summary

- Adds `isValidObjectID()` in `GenerateTransactionBody` to reject transactions whose `object_id` contains non-ASCII or non-printable characters before any write to OpenSearch
- Covers both the delete path (where `ParsedObjectID` is used directly) and the create/update path (after enrichment)
- Adds `ErrInvalidObjectID` constant to `pkg/constants/errors.go`
- Adds 16 new tests: `TestIsValidObjectID` (13 table-driven cases including the exact corrupted pattern from the ticket), plus two integration-level tests verifying no OpenSearch write occurs for invalid IDs

## Ticket

[LFXV2-1464](https://linuxfoundation.atlassian.net/browse/LFXV2-1464)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1464]: https://linuxfoundation.atlassian.net/browse/LFXV2-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ