### PR TITLE
[LFXV2-1464] feat: reject documents with non-ASCII object_id in indexer

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -640,6 +640,22 @@ func (s *IndexerService) EnrichTransaction(ctx context.Context, transaction *con
 	return nil
 }
 
+// isValidObjectID returns true if id is a non-empty string containing only
+// printable, non-space ASCII characters (U+0021–U+007E).
+// Go's range loop replaces invalid UTF-8 bytes with U+FFFD (> 0x7E), so
+// invalid UTF-8 is caught by the same check without a separate utf8 call.
+func isValidObjectID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if r < 0x21 || r > 0x7E {
+			return false
+		}
+	}
+	return true
+}
+
 // GenerateTransactionBody creates a transaction body for indexing
 func (s *IndexerService) GenerateTransactionBody(ctx context.Context, transaction *contracts.LFXTransaction) (*contracts.TransactionBody, error) {
 	logger := logging.FromContext(ctx, s.logger)
@@ -684,6 +700,14 @@ func (s *IndexerService) GenerateTransactionBody(ctx context.Context, transactio
 	case constants.ActionDeleted:
 		body.DeletedAt = &transaction.Timestamp
 		s.setPrincipalFields(body, transaction.ParsedPrincipals, constants.ActionDeleted)
+		if !isValidObjectID(transaction.ParsedObjectID) {
+			err := fmt.Errorf("%s: %q", constants.ErrInvalidObjectID, transaction.ParsedObjectID)
+			logging.LogError(logger, constants.ErrInvalidObjectID, err,
+				"transaction_id", transactionID,
+				"object_type", transaction.ObjectType,
+				"action", canonicalAction)
+			return nil, err
+		}
 		body.ObjectID = transaction.ParsedObjectID
 		body.ObjectRef = transaction.ObjectType + ":" + transaction.ParsedObjectID
 
@@ -712,6 +736,16 @@ func (s *IndexerService) GenerateTransactionBody(ctx context.Context, transactio
 		return nil, fmt.Errorf("failed to enrich transaction data: %w", err)
 	}
 	logger.Debug("Transaction data enrichment completed", "transaction_id", transactionID)
+
+	// Validate object ID before writing to the index
+	if !isValidObjectID(body.ObjectID) {
+		err := fmt.Errorf("%s: %q", constants.ErrInvalidObjectID, body.ObjectID)
+		logging.LogError(logger, constants.ErrInvalidObjectID, err,
+			"transaction_id", transactionID,
+			"object_type", transaction.ObjectType,
+			"action", canonicalAction)
+		return nil, err
+	}
 
 	// Set object reference
 	body.ObjectRef = transaction.ObjectType + ":" + body.ObjectID

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -1509,15 +1509,20 @@ func TestIndexerService_ProcessTransaction_InvalidObjectID_Delete(t *testing.T) 
 		logger,
 	)
 
+	// Use a registered object type and IsV1=true (no auth headers required).
+	// For delete actions, Data must be a string — it is parsed into ParsedObjectID by
+	// parseTransactionData, ensuring the full enrichment pipeline is exercised.
 	transaction := &contracts.LFXTransaction{
-		ObjectType:      "groupsio_member",
-		Action:          constants.ActionDeleted,
-		ParsedObjectID:  "\u05cfz\ufffd\ufffd|", // corrupted binary member ID from LFXV2-1464
-		ParsedPrincipals: []contracts.Principal{},
-		Timestamp:       time.Now(),
+		ObjectType: constants.ObjectTypeProject,
+		Action:     constants.ActionDelete, // V1 uses present-tense; canonicalized to ActionDeleted internally
+		IsV1:       true,
+		Headers:    map[string]string{},
+		Data:       "\u05cfz\ufffd\ufffd|", // corrupted binary member ID from LFXV2-1464
+		Timestamp:  time.Now(),
 	}
 
 	_, err := s.ProcessTransaction(context.Background(), transaction, "test-index")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), constants.ErrInvalidObjectID)
 	assert.Empty(t, mockStorageRepo.IndexCalls, "expected no writes to OpenSearch for corrupted object_id")
 }

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -1444,3 +1444,80 @@ func TestDecodeTransactionData(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidObjectID(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		valid bool
+	}{
+		{name: "uuid", id: "550e8400-e29b-41d4-a716-446655440000", valid: true},
+		{name: "numeric string", id: "123456789", valid: true},
+		{name: "alphanumeric", id: "abc123", valid: true},
+		{name: "printable ASCII with symbols", id: "foo_bar.baz", valid: true},
+		{name: "empty string", id: "", valid: false},
+		{name: "space character", id: "hello world", valid: false},
+		{name: "binary byte 0x00", id: "\x00", valid: false},
+		{name: "binary byte 0x01", id: "\x01abc", valid: false},
+		{name: "high byte 0x80", id: "\x80abc", valid: false},
+		{name: "non-ASCII unicode", id: "abc\u05cfdef", valid: false},
+		{name: "replacement char (invalid UTF-8 proxy)", id: "\uFFFD", valid: false},
+		{name: "tab character", id: "abc\tdef", valid: false},
+		{name: "newline character", id: "abc\ndef", valid: false},
+		// The exact pattern from LFXV2-1464: Hebrew letter + high bytes
+		{name: "corrupted member id from ticket", id: "\u05cfz\ufffd\ufffd|", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidObjectID(tt.id)
+			if got != tt.valid {
+				t.Errorf("isValidObjectID(%q) = %v, want %v", tt.id, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestIndexerService_GenerateTransactionBody_InvalidObjectID_Delete(t *testing.T) {
+	logger, _ := logging.TestLogger(t)
+	s := NewIndexerService(
+		mocks.NewMockStorageRepository(),
+		mocks.NewMockMessagingRepository(),
+		logger,
+	)
+
+	transaction := &contracts.LFXTransaction{
+		ObjectType:      "groupsio_member",
+		Action:          constants.ActionDeleted,
+		ParsedObjectID:  "\u05cfz\ufffd\ufffd|", // corrupted binary member ID from LFXV2-1464
+		ParsedPrincipals: []contracts.Principal{},
+		Timestamp:       time.Now(),
+	}
+
+	body, err := s.GenerateTransactionBody(context.Background(), transaction)
+	require.Error(t, err)
+	assert.Nil(t, body)
+	assert.Contains(t, err.Error(), constants.ErrInvalidObjectID)
+}
+
+func TestIndexerService_ProcessTransaction_InvalidObjectID_Delete(t *testing.T) {
+	mockStorageRepo := mocks.NewMockStorageRepository()
+	logger, _ := logging.TestLogger(t)
+	s := NewIndexerService(
+		mockStorageRepo,
+		mocks.NewMockMessagingRepository(),
+		logger,
+	)
+
+	transaction := &contracts.LFXTransaction{
+		ObjectType:      "groupsio_member",
+		Action:          constants.ActionDeleted,
+		ParsedObjectID:  "\u05cfz\ufffd\ufffd|", // corrupted binary member ID from LFXV2-1464
+		ParsedPrincipals: []contracts.Principal{},
+		Timestamp:       time.Now(),
+	}
+
+	_, err := s.ProcessTransaction(context.Background(), transaction, "test-index")
+	require.Error(t, err)
+	assert.Empty(t, mockStorageRepo.IndexCalls, "expected no writes to OpenSearch for corrupted object_id")
+}

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -30,6 +30,7 @@ const (
 	ErrEnrichmentFailed  = "transaction enrichment failed"
 	ErrMissingObjectID   = "missing or invalid object ID"
 	ErrMissingPublicFlag = "missing or invalid public flag"
+	ErrInvalidObjectID   = "object_id contains non-ASCII or non-printable characters"
 
 	// Storage specific errors
 	ErrMarshalQuery       = "failed to marshal query"

--- a/pkg/constants/errors.go
+++ b/pkg/constants/errors.go
@@ -30,7 +30,7 @@ const (
 	ErrEnrichmentFailed  = "transaction enrichment failed"
 	ErrMissingObjectID   = "missing or invalid object ID"
 	ErrMissingPublicFlag = "missing or invalid public flag"
-	ErrInvalidObjectID   = "object_id contains non-ASCII or non-printable characters"
+	ErrInvalidObjectID   = "object_id must be non-empty and contain only printable non-space ASCII characters (U+0021–U+007E)"
 
 	// Storage specific errors
 	ErrMarshalQuery       = "failed to marshal query"


### PR DESCRIPTION
## Summary

- Adds `isValidObjectID()` in `GenerateTransactionBody` to reject transactions whose `object_id` contains non-ASCII or non-printable characters before any write to OpenSearch
- Covers both the delete path (where `ParsedObjectID` is used directly) and the create/update path (after enrichment)
- Adds `ErrInvalidObjectID` constant to `pkg/constants/errors.go`
- Adds 16 new tests: `TestIsValidObjectID` (14 table-driven cases including the exact corrupted pattern from the ticket), plus two integration-level tests verifying no OpenSearch write occurs for invalid IDs

## Ticket

[LFXV2-1464](https://linuxfoundation.atlassian.net/browse/LFXV2-1464)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1464]: https://linuxfoundation.atlassian.net/browse/LFXV2-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ