### PR TITLE
[LFXV2-1564] fix: NATS slow consumer — messages dropped under load

### DIFF
--- a/cmd/lfx-indexer/cli.go
+++ b/cmd/lfx-indexer/cli.go
@@ -23,6 +23,10 @@ func parseCLIFlags() *config.CLIConfig {
 	noJanitor := flag.Bool("nojanitor", false, "disable janitor (overrides JANITOR_ENABLED)")
 	simpleHealth := flag.Bool("simple-health", logging.GetEnvBool("SIMPLE_HEALTH", false), "use simple 'OK' health responses")
 
+	natsPendingMsgLimit := flag.Int("nats-pending-msg-limit", 0, "NATS subscription pending message limit (0 = use NATS_PENDING_MSG_LIMIT env or default)")
+	natsPendingBytesLimit := flag.Int("nats-pending-bytes-limit", 0, "NATS subscription pending bytes limit (0 = use NATS_PENDING_BYTES_LIMIT env or default)")
+	natsWorkerCount := flag.Int("nats-worker-count", 0, "NATS concurrent message handler goroutines (0 = use NATS_WORKER_COUNT env or default)")
+
 	configCheck := flag.Bool("check-config", false, "Check configuration and exit")
 	help := flag.Bool("help", false, "Show help")
 
@@ -71,13 +75,16 @@ func parseCLIFlags() *config.CLIConfig {
 	flag.Parse()
 
 	return &config.CLIConfig{
-		Port:         *port,
-		Debug:        *debug,
-		Bind:         *bind,
-		NoJanitor:    *noJanitor,
-		SimpleHealth: *simpleHealth,
-		ConfigCheck:  *configCheck,
-		Help:         *help,
+		Port:                  *port,
+		Debug:                 *debug,
+		Bind:                  *bind,
+		NoJanitor:             *noJanitor,
+		SimpleHealth:          *simpleHealth,
+		ConfigCheck:           *configCheck,
+		Help:                  *help,
+		NATSPendingMsgLimit:   *natsPendingMsgLimit,
+		NATSPendingBytesLimit: *natsPendingBytesLimit,
+		NATSWorkerCount:       *natsWorkerCount,
 	}
 }
 

--- a/cmd/lfx-indexer/cli.go
+++ b/cmd/lfx-indexer/cli.go
@@ -42,6 +42,9 @@ func parseCLIFlags() *config.CLIConfig {
 		fmt.Fprintf(os.Stderr, "  --bind <iface>   Interface to bind on (default: *, use 0.0.0.0 for all)\n")
 		fmt.Fprintf(os.Stderr, "  --nojanitor      Disable background janitor service\n")
 		fmt.Fprintf(os.Stderr, "  --simple-health  Use simple 'OK' health responses for K8s\n")
+		fmt.Fprintf(os.Stderr, "  --nats-pending-msg-limit <n>   NATS subscription pending message limit (0 = use env/default)\n")
+		fmt.Fprintf(os.Stderr, "  --nats-pending-bytes-limit <n> NATS subscription pending bytes limit (0 = use env/default)\n")
+		fmt.Fprintf(os.Stderr, "  --nats-worker-count <n>        NATS concurrent message handler goroutines (0 = use env/default)\n")
 		fmt.Fprintf(os.Stderr, "  --check-config   Check configuration and exit\n")
 		fmt.Fprintf(os.Stderr, "  --help           Show this help message\n\n")
 
@@ -63,6 +66,9 @@ func parseCLIFlags() *config.CLIConfig {
 		fmt.Fprintf(os.Stderr, "    LOG_LEVEL=info         Logging level (debug,info,warn,error)\n")
 		fmt.Fprintf(os.Stderr, "    LOG_FORMAT=json        Log format (json,text)\n")
 		fmt.Fprintf(os.Stderr, "    NATS_URL=nats://...    NATS server URL\n")
+		fmt.Fprintf(os.Stderr, "    NATS_PENDING_MSG_LIMIT=1000000     NATS pending message limit\n")
+		fmt.Fprintf(os.Stderr, "    NATS_PENDING_BYTES_LIMIT=536870912 NATS pending bytes limit\n")
+		fmt.Fprintf(os.Stderr, "    NATS_WORKER_COUNT=100              NATS concurrent handlers\n")
 		fmt.Fprintf(os.Stderr, "    OPENSEARCH_URL=http... OpenSearch URL\n\n")
 
 		fmt.Fprintf(os.Stderr, "Configuration precedence: CLI flags > Environment variables > Defaults\n\n")

--- a/cmd/lfx-indexer/server.go
+++ b/cmd/lfx-indexer/server.go
@@ -11,8 +11,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/container"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/container"
 )
 
 // createHTTPServer creates and configures the HTTP server with health check routes

--- a/internal/application/message_processor.go
+++ b/internal/application/message_processor.go
@@ -325,6 +325,12 @@ func (h *indexingHandler) HandleWithReply(ctx context.Context, data []byte, subj
 	messageID := h.useCase.generateMessageID()
 	logger := logging.FromContext(ctx, h.useCase.logger)
 
+	// When the caller supplied a reply subject they are waiting for an ACK, so
+	// use refresh=wait_for to make the document immediately searchable.
+	if reply != nil {
+		ctx = logging.WithRefreshWaitFor(ctx)
+	}
+
 	// Route to appropriate processing method based on subject
 	var err error
 	var messageType string

--- a/internal/application/message_processor_test.go
+++ b/internal/application/message_processor_test.go
@@ -598,6 +598,78 @@ func TestIndexingHandler_HandleWithReply_NoReply(t *testing.T) {
 	mockMessagingRepo.AssertExpectations(t)
 }
 
+// Test that HandleWithReply sets refresh=wait_for in context when reply is provided
+func TestIndexingHandler_HandleWithReply_SetsRefreshWaitFor_WithReply(t *testing.T) {
+	mp, mockMessagingRepo, mockStorageRepo := setupTestMessageProcessor()
+	ctx := context.Background()
+
+	testData := map[string]any{
+		"action": "created",
+		"data": map[string]any{
+			"id":     "test-123",
+			"name":   "Test Project",
+			"public": true,
+		},
+		"headers": map[string]string{
+			"authorization": "Bearer test-token",
+		},
+	}
+	data, _ := json.Marshal(testData)
+	subject := "lfx.index.project"
+
+	replyFunc := func(_ []byte) error { return nil }
+
+	// Index must be called with a context that has NeedsRefreshWaitFor=true
+	mockStorageRepo.On("Index", mock.MatchedBy(func(c context.Context) bool {
+		return logging.NeedsRefreshWaitFor(c)
+	}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMessagingRepo.On("ParsePrincipals", mock.Anything, mock.Anything).Return([]contracts.Principal{}, nil)
+	mockMessagingRepo.On("Publish", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	handler := &indexingHandler{useCase: mp}
+	err := handler.HandleWithReply(ctx, data, subject, replyFunc)
+
+	assert.NoError(t, err)
+	mockStorageRepo.AssertExpectations(t)
+	mockMessagingRepo.AssertExpectations(t)
+}
+
+// Test that HandleWithReply does NOT set refresh=wait_for when no reply
+func TestIndexingHandler_HandleWithReply_NoRefreshWaitFor_WithoutReply(t *testing.T) {
+	mp, mockMessagingRepo, mockStorageRepo := setupTestMessageProcessor()
+	ctx := context.Background()
+
+	testData := map[string]any{
+		"action": "created",
+		"data": map[string]any{
+			"id":     "test-123",
+			"name":   "Test Project",
+			"public": true,
+		},
+		"headers": map[string]string{
+			"authorization": "Bearer test-token",
+		},
+	}
+	data, _ := json.Marshal(testData)
+	subject := "lfx.index.project"
+
+	// Index must be called with a context that does NOT have NeedsRefreshWaitFor=true
+	mockStorageRepo.On("Index", mock.MatchedBy(func(c context.Context) bool {
+		return !logging.NeedsRefreshWaitFor(c)
+	}), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMessagingRepo.On("ParsePrincipals", mock.Anything, mock.Anything).Return([]contracts.Principal{
+		{Principal: "test-user", Email: "test@example.com"},
+	}, nil)
+	mockMessagingRepo.On("Publish", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	handler := &indexingHandler{useCase: mp}
+	err := handler.HandleWithReply(ctx, data, subject, nil)
+
+	assert.NoError(t, err)
+	mockStorageRepo.AssertExpectations(t)
+	mockMessagingRepo.AssertExpectations(t)
+}
+
 // Test generateMessageID uniqueness
 func TestMessageProcessor_GenerateMessageID(t *testing.T) {
 	mp, _, _ := setupTestMessageProcessor()

--- a/internal/application/message_processor_test.go
+++ b/internal/application/message_processor_test.go
@@ -12,14 +12,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/services"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/cleanup"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 // Test helper functions

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -103,17 +103,17 @@ func NewContainer(logger *slog.Logger, cliConfig *config.CLIConfig) (*Container,
 			logger.Info("Bind address set by CLI flag", "bind", cliConfig.Bind)
 		}
 
-		if cliConfig.NATSPendingMsgLimit > 0 {
+		if cliConfig.NATSPendingMsgLimit != 0 {
 			config.NATS.PendingMsgLimit = cliConfig.NATSPendingMsgLimit
 			logger.Info("NATS pending message limit overridden by CLI flag", "pending_msg_limit", cliConfig.NATSPendingMsgLimit)
 		}
 
-		if cliConfig.NATSPendingBytesLimit > 0 {
+		if cliConfig.NATSPendingBytesLimit != 0 {
 			config.NATS.PendingBytesLimit = cliConfig.NATSPendingBytesLimit
 			logger.Info("NATS pending bytes limit overridden by CLI flag", "pending_bytes_limit", cliConfig.NATSPendingBytesLimit)
 		}
 
-		if cliConfig.NATSWorkerCount > 0 {
+		if cliConfig.NATSWorkerCount != 0 {
 			config.NATS.WorkerCount = cliConfig.NATSWorkerCount
 			logger.Info("NATS worker count overridden by CLI flag", "worker_count", cliConfig.NATSWorkerCount)
 		}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -243,6 +243,9 @@ func (c *Container) initializeRepositories() error {
 		c.AuthRepository,
 		c.Logger,
 		c.Config.NATS.DrainTimeout,
+		c.Config.NATS.PendingMsgLimit,
+		c.Config.NATS.PendingBytesLimit,
+		c.Config.NATS.WorkerCount,
 	)
 
 	// Initialize cleanup repository (background operations)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -102,6 +102,21 @@ func NewContainer(logger *slog.Logger, cliConfig *config.CLIConfig) (*Container,
 		if cliConfig.Bind != "*" && cliConfig.Bind != "" {
 			logger.Info("Bind address set by CLI flag", "bind", cliConfig.Bind)
 		}
+
+		if cliConfig.NATSPendingMsgLimit > 0 {
+			config.NATS.PendingMsgLimit = cliConfig.NATSPendingMsgLimit
+			logger.Info("NATS pending message limit overridden by CLI flag", "pending_msg_limit", cliConfig.NATSPendingMsgLimit)
+		}
+
+		if cliConfig.NATSPendingBytesLimit > 0 {
+			config.NATS.PendingBytesLimit = cliConfig.NATSPendingBytesLimit
+			logger.Info("NATS pending bytes limit overridden by CLI flag", "pending_bytes_limit", cliConfig.NATSPendingBytesLimit)
+		}
+
+		if cliConfig.NATSWorkerCount > 0 {
+			config.NATS.WorkerCount = cliConfig.NATSWorkerCount
+			logger.Info("NATS worker count overridden by CLI flag", "worker_count", cliConfig.NATSWorkerCount)
+		}
 	}
 
 	// Validate configuration

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/config"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/config"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 )
 
 // TestContainer_NewContainer tests the container creation and initialization

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -11,13 +11,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/mocks"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIndexerService_ProcessTransaction_Success(t *testing.T) {
@@ -1506,11 +1507,11 @@ func TestIndexerService_GenerateTransactionBody_InvalidObjectID_Delete(t *testin
 	)
 
 	transaction := &contracts.LFXTransaction{
-		ObjectType:      "groupsio_member",
-		Action:          constants.ActionDeleted,
-		ParsedObjectID:  "\u05cfz\ufffd\ufffd|", // corrupted binary member ID from LFXV2-1464
+		ObjectType:       "groupsio_member",
+		Action:           constants.ActionDeleted,
+		ParsedObjectID:   "\u05cfz\ufffd\ufffd|", // corrupted binary member ID from LFXV2-1464
 		ParsedPrincipals: []contracts.Principal{},
-		Timestamp:       time.Now(),
+		Timestamp:        time.Now(),
 	}
 
 	body, err := s.GenerateTransactionBody(context.Background(), transaction)

--- a/internal/enrichers/committee_member_enricher_test.go
+++ b/internal/enrichers/committee_member_enricher_test.go
@@ -6,10 +6,11 @@ package enrichers
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestCommitteeMemberEnricher_setAccessControl(t *testing.T) {

--- a/internal/enrichers/default_enricher_test.go
+++ b/internal/enrichers/default_enricher_test.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestDefaultEnricher_ObjectType(t *testing.T) {

--- a/internal/enrichers/groupsio_mailing_list_settings_enricher_test.go
+++ b/internal/enrichers/groupsio_mailing_list_settings_enricher_test.go
@@ -6,10 +6,11 @@ package enrichers
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestGroupsIOMailingListSettingsEnricher_ObjectType(t *testing.T) {

--- a/internal/enrichers/groupsio_service_enricher_test.go
+++ b/internal/enrichers/groupsio_service_enricher_test.go
@@ -6,10 +6,11 @@ package enrichers
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestGroupsIOServiceEnricher_ObjectType(t *testing.T) {

--- a/internal/enrichers/groupsio_service_settings_enricher_test.go
+++ b/internal/enrichers/groupsio_service_settings_enricher_test.go
@@ -6,10 +6,11 @@ package enrichers
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestGroupsIOServiceSettingsEnricher_ObjectType(t *testing.T) {

--- a/internal/enrichers/project_enricher_test.go
+++ b/internal/enrichers/project_enricher_test.go
@@ -6,10 +6,11 @@ package enrichers
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestProjectEnricher_EnrichData(t *testing.T) {

--- a/internal/enrichers/project_settings_enricher_test.go
+++ b/internal/enrichers/project_settings_enricher_test.go
@@ -6,10 +6,11 @@ package enrichers
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestProjectSettingsEnricher_ObjectType(t *testing.T) {

--- a/internal/infrastructure/auth/auth_repository_test.go
+++ b/internal/infrastructure/auth/auth_repository_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 )
 
 // Test constants

--- a/internal/infrastructure/cleanup/cleanup_repository_test.go
+++ b/internal/infrastructure/cleanup/cleanup_repository_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 )
 
 // MockTransactionRepository implements the contracts.TransactionRepository interface for testing

--- a/internal/infrastructure/config/app_config.go
+++ b/internal/infrastructure/config/app_config.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 // AppConfig represents the application configuration
@@ -43,6 +45,9 @@ type NATSConfig struct {
 	V1IndexingSubject string        `json:"v1_indexing_subject"`
 	Queue             string        `json:"queue"`
 	DrainTimeout      time.Duration `json:"drain_timeout"`
+	PendingMsgLimit   int           `json:"pending_msg_limit"`
+	PendingBytesLimit int           `json:"pending_bytes_limit"`
+	WorkerCount       int           `json:"worker_count"`
 }
 
 // OpenSearchConfig contains OpenSearch configuration
@@ -106,6 +111,9 @@ func LoadConfig() (*AppConfig, error) {
 			V1IndexingSubject: getEnvStringWithLogging("NATS_V1_INDEXING_SUBJECT", "lfx.v1.index.>", envVarsUsed, defaultsUsed, logger),
 			Queue:             getEnvStringWithLogging("NATS_QUEUE", "lfx.indexer.queue", envVarsUsed, defaultsUsed, logger),
 			DrainTimeout:      getEnvDurationWithLogging("NATS_DRAIN_TIMEOUT", 55*time.Second, envVarsUsed, defaultsUsed, logger),
+			PendingMsgLimit:   getEnvIntWithLogging("NATS_PENDING_MSG_LIMIT", constants.DefaultPendingMsgLimit, envVarsUsed, defaultsUsed, logger),
+			PendingBytesLimit: getEnvIntWithLogging("NATS_PENDING_BYTES_LIMIT", constants.DefaultPendingBytesLimit, envVarsUsed, defaultsUsed, logger),
+			WorkerCount:       getEnvIntWithLogging("NATS_WORKER_COUNT", constants.DefaultWorkerCount, envVarsUsed, defaultsUsed, logger),
 		},
 		OpenSearch: OpenSearchConfig{
 			URL:   getEnvStringWithLogging("OPENSEARCH_URL", "http://localhost:9200", envVarsUsed, defaultsUsed, logger),

--- a/internal/infrastructure/config/app_config.go
+++ b/internal/infrastructure/config/app_config.go
@@ -246,6 +246,18 @@ func (c *AppConfig) validateNATS() error {
 		return fmt.Errorf("NATS connection timeout must be positive, got: %v", c.NATS.ConnectionTimeout)
 	}
 
+	if c.NATS.PendingMsgLimit <= 0 {
+		return fmt.Errorf("NATS pending message limit must be positive, got: %d", c.NATS.PendingMsgLimit)
+	}
+
+	if c.NATS.PendingBytesLimit <= 0 {
+		return fmt.Errorf("NATS pending bytes limit must be positive, got: %d", c.NATS.PendingBytesLimit)
+	}
+
+	if c.NATS.WorkerCount <= 0 {
+		return fmt.Errorf("NATS worker count must be positive, got: %d", c.NATS.WorkerCount)
+	}
+
 	return nil
 }
 

--- a/internal/infrastructure/config/cli_config.go
+++ b/internal/infrastructure/config/cli_config.go
@@ -13,4 +13,8 @@ type CLIConfig struct {
 	SimpleHealth bool
 	ConfigCheck  bool
 	Help         bool
+	// NATS overrides — zero value means "not set, use env/default"
+	NATSPendingMsgLimit   int
+	NATSPendingBytesLimit int
+	NATSWorkerCount       int
 }

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -11,38 +11,45 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nats-io/nats.go"
+
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
-	"github.com/nats-io/nats.go"
 )
 
 // MessagingRepository implements the MessagingRepository interface for NATS operations
 type MessagingRepository struct {
-	conn           *nats.Conn
-	authRepo       contracts.AuthRepository
-	logger         *slog.Logger
-	subscriptions  []*nats.Subscription
-	mu             sync.RWMutex
-	drainTimeout   time.Duration
-	isShuttingDown bool
+	conn              *nats.Conn
+	authRepo          contracts.AuthRepository
+	logger            *slog.Logger
+	subscriptions     []*nats.Subscription
+	mu                sync.RWMutex
+	drainTimeout      time.Duration
+	isShuttingDown    bool
+	pendingMsgLimit   int
+	pendingBytesLimit int
+	sem               chan struct{}
 }
 
 // NewMessagingRepository creates a new NATS messaging repository with auth delegation
-func NewMessagingRepository(conn *nats.Conn, authRepo contracts.AuthRepository, logger *slog.Logger, drainTimeout time.Duration) *MessagingRepository {
+func NewMessagingRepository(conn *nats.Conn, authRepo contracts.AuthRepository, logger *slog.Logger, drainTimeout time.Duration, pendingMsgLimit int, pendingBytesLimit int, workerCount int) *MessagingRepository {
 	msgLogger := logging.WithComponent(logger, constants.ComponentNATS)
 
 	repo := &MessagingRepository{
-		conn:           conn,
-		authRepo:       authRepo,
-		logger:         msgLogger,
-		subscriptions:  make([]*nats.Subscription, 0),
-		drainTimeout:   drainTimeout,
-		isShuttingDown: false,
+		conn:              conn,
+		authRepo:          authRepo,
+		logger:            msgLogger,
+		subscriptions:     make([]*nats.Subscription, 0),
+		drainTimeout:      drainTimeout,
+		isShuttingDown:    false,
+		pendingMsgLimit:   pendingMsgLimit,
+		pendingBytesLimit: pendingBytesLimit,
+		sem:               make(chan struct{}, workerCount),
 	}
 
 	// Log initialization
-	msgLogger.Info("NATS messaging repository initialized", "drain_timeout", drainTimeout, "auth_repo_configured", authRepo != nil)
+	msgLogger.Info("NATS messaging repository initialized", "drain_timeout", drainTimeout, "worker_count", workerCount, "auth_repo_configured", authRepo != nil)
 
 	return repo
 }
@@ -60,15 +67,19 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
-		// Generate request_id at NATS entry point
-		ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+		data := msg.Data
+		msgSubject := msg.Subject
+		go func() {
+			r.sem <- struct{}{}
+			defer func() { <-r.sem }()
 
-		logger.Debug("NATS message received", "subject", msg.Subject, "size", len(msg.Data))
+			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+			logger.Debug("NATS message received", "subject", msgSubject, "size", len(data))
 
-		// Handle the message
-		if err := handler.Handle(ctx, msg.Data, msg.Subject); err != nil {
-			logger.Error("Message handler failed", "error", err.Error())
-		}
+			if err := handler.Handle(ctx, data, msgSubject); err != nil {
+				logger.Error("Message handler failed", "error", err.Error())
+			}
+		}()
 	}
 
 	// Subscribe to the subject
@@ -94,15 +105,20 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
-		// Generate request_id at NATS entry point
-		ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+		// Capture message data before handing off to goroutine
+		data := msg.Data
+		subject := msg.Subject
+		go func() {
+			r.sem <- struct{}{}
+			defer func() { <-r.sem }()
 
-		logger.Debug("NATS queue message received", "subject", msg.Subject, "queue", queue, "size", len(msg.Data))
+			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+			logger.Debug("NATS queue message received", "subject", subject, "queue", queue, "size", len(data))
 
-		// Handle the message
-		if err := handler.Handle(ctx, msg.Data, msg.Subject); err != nil {
-			logger.Error("Queue message handler failed", "queue", queue, "error", err.Error())
-		}
+			if err := handler.Handle(ctx, data, subject); err != nil {
+				logger.Error("Queue message handler failed", "queue", queue, "error", err.Error())
+			}
+		}()
 	}
 
 	// Subscribe to the subject with queue group
@@ -110,6 +126,10 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 	if err != nil {
 		r.logger.Error("Failed to queue subscribe to NATS", "subject", subject, "queue", queue, "error", err.Error())
 		return fmt.Errorf("failed to queue subscribe to subject %s with queue %s: %w", subject, queue, err)
+	}
+
+	if err := sub.SetPendingLimits(r.pendingMsgLimit, r.pendingBytesLimit); err != nil {
+		r.logger.Warn("Failed to set pending limits on subscription", "subject", subject, "error", err.Error())
 	}
 
 	// Store the subscription for cleanup
@@ -128,29 +148,34 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 
 	// Create the NATS message handler with reply support
 	natsHandler := func(msg *nats.Msg) {
-		// Generate request_id at NATS entry point
-		ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+		// Capture fields needed by goroutine before msg may be reused
+		data := msg.Data
+		msgSubject := msg.Subject
+		replySubject := msg.Reply
 
-		logger.Debug("NATS queue message with reply received", "subject", msg.Subject, "queue", queue, "has_reply", msg.Reply != "")
+		go func() {
+			r.sem <- struct{}{}
+			defer func() { <-r.sem }()
 
-		// Create reply function if message has reply subject
-		var replyFunc func([]byte) error
-		if msg.Reply != "" {
-			replyFunc = func(data []byte) error {
-				logger.Debug("Sending reply to NATS message", "reply_subject", msg.Reply, "reply_size", len(data))
+			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+			logger.Debug("NATS queue message with reply received", "subject", msgSubject, "queue", queue, "has_reply", replySubject != "")
 
-				err := msg.Respond(data)
-				if err != nil {
-					logger.Error("Failed to send reply", "reply_subject", msg.Reply, "error", err.Error())
+			var replyFunc func([]byte) error
+			if replySubject != "" {
+				replyFunc = func(replyData []byte) error {
+					logger.Debug("Sending reply to NATS message", "reply_subject", replySubject, "reply_size", len(replyData))
+					if err := msg.Respond(replyData); err != nil {
+						logger.Error("Failed to send reply", "reply_subject", replySubject, "error", err.Error())
+						return err
+					}
+					return nil
 				}
-				return err
 			}
-		}
 
-		// Handle the message with reply support
-		if err := handler.HandleWithReply(ctx, msg.Data, msg.Subject, replyFunc); err != nil {
-			logger.Error("Queue message with reply handler failed", "queue", queue, "error", err.Error())
-		}
+			if err := handler.HandleWithReply(ctx, data, msgSubject, replyFunc); err != nil {
+				logger.Error("Queue message with reply handler failed", "queue", queue, "error", err.Error())
+			}
+		}()
 	}
 
 	// Subscribe to the subject with queue group
@@ -158,6 +183,10 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 	if err != nil {
 		r.logger.Error("Failed to queue subscribe with reply to NATS", "subject", subject, "queue", queue, "error", err.Error())
 		return fmt.Errorf("failed to queue subscribe with reply to subject %s with queue %s: %w", subject, queue, err)
+	}
+
+	if err := sub.SetPendingLimits(r.pendingMsgLimit, r.pendingBytesLimit); err != nil {
+		r.logger.Warn("Failed to set pending limits on subscription", "subject", subject, "error", err.Error())
 	}
 
 	// Store the subscription for cleanup

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -545,6 +545,9 @@ func (r *MessagingRepository) GetMetrics() map[string]interface{} {
 		connected = r.conn.IsConnected()
 	}
 
+	workerCapacity := cap(r.sem)
+	workersInFlight := workerCapacity - len(r.sem)
+
 	return map[string]interface{}{
 		"connection_status":    connectionStatus,
 		"connected":            connected,
@@ -554,6 +557,8 @@ func (r *MessagingRepository) GetMetrics() map[string]interface{} {
 		"is_shutting_down":     r.isShuttingDown,
 		"drain_timeout":        r.drainTimeout,
 		"auth_repo_configured": r.authRepo != nil,
+		"worker_capacity":      workerCapacity,
+		"workers_in_flight":    workersInFlight,
 	}
 }
 

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -25,6 +25,7 @@ type MessagingRepository struct {
 	logger            *slog.Logger
 	subscriptions     []*nats.Subscription
 	mu                sync.RWMutex
+	wg                sync.WaitGroup
 	drainTimeout      time.Duration
 	isShuttingDown    bool
 	pendingMsgLimit   int
@@ -35,6 +36,11 @@ type MessagingRepository struct {
 // NewMessagingRepository creates a new NATS messaging repository with auth delegation
 func NewMessagingRepository(conn *nats.Conn, authRepo contracts.AuthRepository, logger *slog.Logger, drainTimeout time.Duration, pendingMsgLimit int, pendingBytesLimit int, workerCount int) *MessagingRepository {
 	msgLogger := logging.WithComponent(logger, constants.ComponentNATS)
+
+	if workerCount <= 0 {
+		msgLogger.Warn("Invalid workerCount, falling back to default", "provided", workerCount, "default", constants.DefaultWorkerCount)
+		workerCount = constants.DefaultWorkerCount
+	}
 
 	repo := &MessagingRepository{
 		conn:              conn,
@@ -70,8 +76,12 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
 		r.sem <- struct{}{}
+		r.wg.Add(1)
 		go func() {
-			defer func() { <-r.sem }()
+			defer func() {
+				<-r.sem
+				r.wg.Done()
+			}()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
 			logger.Debug("NATS message received", "subject", msgSubject, "size", len(data))
@@ -109,8 +119,12 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 		data := append([]byte(nil), msg.Data...)
 		subject := msg.Subject
 		r.sem <- struct{}{}
+		r.wg.Add(1)
 		go func() {
-			defer func() { <-r.sem }()
+			defer func() {
+				<-r.sem
+				r.wg.Done()
+			}()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
 			logger.Debug("NATS queue message received", "subject", subject, "queue", queue, "size", len(data))
@@ -129,7 +143,8 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 	}
 
 	if err := sub.SetPendingLimits(r.pendingMsgLimit, r.pendingBytesLimit); err != nil {
-		r.logger.Warn("Failed to set pending limits on subscription", "subject", subject, "error", err.Error())
+		_ = sub.Unsubscribe()
+		return fmt.Errorf("failed to set pending limits on subscription %s: %w", subject, err)
 	}
 
 	// Store the subscription for cleanup
@@ -154,8 +169,12 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 		replySubject := msg.Reply
 
 		r.sem <- struct{}{}
+		r.wg.Add(1)
 		go func() {
-			defer func() { <-r.sem }()
+			defer func() {
+				<-r.sem
+				r.wg.Done()
+			}()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
 			logger.Debug("NATS queue message with reply received", "subject", msgSubject, "queue", queue, "has_reply", replySubject != "")
@@ -186,7 +205,8 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 	}
 
 	if err := sub.SetPendingLimits(r.pendingMsgLimit, r.pendingBytesLimit); err != nil {
-		r.logger.Warn("Failed to set pending limits on subscription", "subject", subject, "error", err.Error())
+		_ = sub.Unsubscribe()
+		return fmt.Errorf("failed to set pending limits on subscription %s: %w", subject, err)
 	}
 
 	// Store the subscription for cleanup
@@ -265,6 +285,11 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 	}():
 		// Drain completed successfully
 	}
+
+	// Wait for all in-flight handler goroutines to finish.
+	// Conn.Drain() only waits for callbacks to return, not for goroutines
+	// spawned inside them, so we track them with a WaitGroup.
+	r.wg.Wait()
 
 	r.logger.Info("NATS drain completed successfully", "subscriptions_processed", totalSubscriptions)
 	return nil

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -73,6 +73,10 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 		return fmt.Errorf("cannot subscribe to %s: repository is shutting down", subject)
 	}
 
+	if !r.IsConnected() {
+		return fmt.Errorf("cannot subscribe to %s: NATS connection not available", subject)
+	}
+
 	r.logger.InfoContext(ctx, "Creating NATS subscription", "subject", subject)
 
 	// Create the NATS message handler
@@ -122,6 +126,10 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 
 	if r.isShuttingDown {
 		return fmt.Errorf("cannot queue subscribe to %s: repository is shutting down", subject)
+	}
+
+	if !r.IsConnected() {
+		return fmt.Errorf("cannot queue subscribe to %s: NATS connection not available", subject)
 	}
 
 	r.logger.InfoContext(ctx, "Creating NATS queue subscription", "subject", subject, "queue", queue)
@@ -174,6 +182,10 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 
 	if r.isShuttingDown {
 		return fmt.Errorf("cannot queue subscribe with reply to %s: repository is shutting down", subject)
+	}
+
+	if !r.IsConnected() {
+		return fmt.Errorf("cannot queue subscribe with reply to %s: NATS connection not available", subject)
 	}
 
 	r.logger.InfoContext(ctx, "Creating NATS queue subscription with reply", "subject", subject, "queue", queue)
@@ -256,10 +268,11 @@ func (r *MessagingRepository) Publish(ctx context.Context, subject string, data 
 
 // waitForHandlers waits for in-flight message handler goroutines to finish,
 // bounded by the provided timeout so shutdown cannot hang indefinitely.
-func (r *MessagingRepository) waitForHandlers(timeout time.Duration) {
+// Returns true if the wait timed out, false if all handlers finished in time.
+func (r *MessagingRepository) waitForHandlers(timeout time.Duration) bool {
 	if timeout <= 0 {
 		r.logger.Warn("No time remaining to wait for in-flight NATS handlers")
-		return
+		return false
 	}
 	done := make(chan struct{})
 	go func() {
@@ -268,8 +281,10 @@ func (r *MessagingRepository) waitForHandlers(timeout time.Duration) {
 	}()
 	select {
 	case <-done:
+		return false
 	case <-time.After(timeout):
 		r.logger.Warn("Timed out waiting for in-flight NATS handlers", "timeout", timeout)
+		return true
 	}
 }
 
@@ -349,23 +364,7 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 	// Wait for all in-flight handler goroutines to finish, bounded by the
 	// remaining drain budget. Conn.Drain() only waits for callbacks to return,
 	// not for goroutines spawned inside them, so we track them with a WaitGroup.
-	handlersTimedOut := false
-	remaining := time.Until(deadline)
-	if remaining > 0 {
-		done := make(chan struct{})
-		go func() {
-			r.wg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(remaining):
-			handlersTimedOut = true
-			r.logger.Warn("Timed out waiting for in-flight NATS handlers", "timeout", remaining)
-		}
-	} else {
-		r.logger.Warn("No time remaining to wait for in-flight NATS handlers")
-	}
+	handlersTimedOut := r.waitForHandlers(time.Until(deadline))
 
 	if drainTimedOut || handlersTimedOut {
 		r.logger.Warn("NATS drain did not complete cleanly", "drain_timed_out", drainTimedOut, "handlers_timed_out", handlersTimedOut, "subscriptions_processed", totalSubscriptions)

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -99,6 +99,11 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 		return fmt.Errorf("failed to subscribe to subject %s: %w", subject, err)
 	}
 
+	if err := sub.SetPendingLimits(r.pendingMsgLimit, r.pendingBytesLimit); err != nil {
+		_ = sub.Unsubscribe()
+		return fmt.Errorf("failed to set pending limits on subscription %s: %w", subject, err)
+	}
+
 	// Store the subscription for cleanup
 	r.subscriptions = append(r.subscriptions, sub)
 

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -67,10 +67,10 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
-		data := msg.Data
+		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
+		r.sem <- struct{}{}
 		go func() {
-			r.sem <- struct{}{}
 			defer func() { <-r.sem }()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
@@ -105,11 +105,11 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
-		// Capture message data before handing off to goroutine
-		data := msg.Data
+		// Deep-copy message data before handing off to goroutine
+		data := append([]byte(nil), msg.Data...)
 		subject := msg.Subject
+		r.sem <- struct{}{}
 		go func() {
-			r.sem <- struct{}{}
 			defer func() { <-r.sem }()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
@@ -148,13 +148,13 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 
 	// Create the NATS message handler with reply support
 	natsHandler := func(msg *nats.Msg) {
-		// Capture fields needed by goroutine before msg may be reused
-		data := msg.Data
+		// Deep-copy fields before msg may be reused after callback returns
+		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
 		replySubject := msg.Reply
 
+		r.sem <- struct{}{}
 		go func() {
-			r.sem <- struct{}{}
 			defer func() { <-r.sem }()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
@@ -164,7 +164,7 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 			if replySubject != "" {
 				replyFunc = func(replyData []byte) error {
 					logger.Debug("Sending reply to NATS message", "reply_subject", replySubject, "reply_size", len(replyData))
-					if err := msg.Respond(replyData); err != nil {
+					if err := r.conn.Publish(replySubject, replyData); err != nil {
 						logger.Error("Failed to send reply", "reply_subject", replySubject, "error", err.Error())
 						return err
 					}

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -581,7 +581,7 @@ func (r *MessagingRepository) GetMetrics() map[string]interface{} {
 	}
 
 	workerCapacity := cap(r.sem)
-	workersInFlight := workerCapacity - len(r.sem)
+	workersInFlight := len(r.sem)
 
 	return map[string]interface{}{
 		"connection_status":    connectionStatus,

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -237,6 +237,25 @@ func (r *MessagingRepository) Publish(ctx context.Context, subject string, data 
 	return nil
 }
 
+// waitForHandlers waits for in-flight message handler goroutines to finish,
+// bounded by the provided timeout so shutdown cannot hang indefinitely.
+func (r *MessagingRepository) waitForHandlers(timeout time.Duration) {
+	if timeout <= 0 {
+		r.logger.Warn("No time remaining to wait for in-flight NATS handlers")
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		r.logger.Warn("Timed out waiting for in-flight NATS handlers", "timeout", timeout)
+	}
+}
+
 // DrainWithTimeout performs graceful NATS connection drain with timeout
 func (r *MessagingRepository) DrainWithTimeout() error {
 	r.mu.Lock()
@@ -246,18 +265,24 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 
 	r.logger.Info("Starting NATS graceful drain sequence", "timeout", r.drainTimeout, "subscriptions", totalSubscriptions)
 
+	// Record the deadline so we can compute remaining time for wg.Wait().
+	deadline := time.Now().Add(r.drainTimeout)
+
 	if r.conn == nil {
 		r.logger.Warn("NATS connection is nil, skipping drain")
+		r.waitForHandlers(r.drainTimeout)
 		return nil
 	}
 
 	if r.conn.IsClosed() {
 		r.logger.Info("NATS connection already closed, no drain needed")
+		r.waitForHandlers(r.drainTimeout)
 		return nil
 	}
 
 	if r.conn.IsDraining() {
 		r.logger.Info("NATS connection already draining, waiting for completion")
+		r.waitForHandlers(r.drainTimeout)
 		return nil
 	}
 
@@ -286,10 +311,10 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 		// Drain completed successfully
 	}
 
-	// Wait for all in-flight handler goroutines to finish.
-	// Conn.Drain() only waits for callbacks to return, not for goroutines
-	// spawned inside them, so we track them with a WaitGroup.
-	r.wg.Wait()
+	// Wait for all in-flight handler goroutines to finish, bounded by the
+	// remaining drain budget. Conn.Drain() only waits for callbacks to return,
+	// not for goroutines spawned inside them, so we track them with a WaitGroup.
+	r.waitForHandlers(time.Until(deadline))
 
 	r.logger.Info("NATS drain completed successfully", "subscriptions_processed", totalSubscriptions)
 	return nil

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -299,7 +299,23 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 
 	if r.conn.IsDraining() {
 		r.logger.Info("NATS connection already draining, waiting for completion")
-		r.waitForHandlers(r.drainTimeout)
+		// Callbacks can still fire until the connection is fully closed, so
+		// wait for IsClosed before calling wg.Wait() to avoid a concurrent
+		// Add/Wait panic.
+		drainDone := make(chan struct{})
+		go func() {
+			for !r.conn.IsClosed() {
+				time.Sleep(100 * time.Millisecond)
+			}
+			close(drainDone)
+		}()
+		select {
+		case <-drainDone:
+		case <-time.After(r.drainTimeout):
+			r.logger.Warn("Timed out waiting for ongoing NATS drain", "timeout", r.drainTimeout)
+			return fmt.Errorf("timed out waiting for ongoing NATS drain after %s", r.drainTimeout)
+		}
+		r.waitForHandlers(time.Until(deadline))
 		return nil
 	}
 
@@ -353,7 +369,14 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 
 	if drainTimedOut || handlersTimedOut {
 		r.logger.Warn("NATS drain did not complete cleanly", "drain_timed_out", drainTimedOut, "handlers_timed_out", handlersTimedOut, "subscriptions_processed", totalSubscriptions)
-		return fmt.Errorf("NATS drain timed out after %s", r.drainTimeout)
+		switch {
+		case drainTimedOut && handlersTimedOut:
+			return fmt.Errorf("NATS drain and in-flight handler wait both timed out after %s", r.drainTimeout)
+		case drainTimedOut:
+			return fmt.Errorf("NATS drain timed out after %s", r.drainTimeout)
+		default: // handlersTimedOut only
+			return fmt.Errorf("NATS drain completed but timed out waiting for in-flight handlers to finish")
+		}
 	}
 
 	r.logger.Info("NATS drain completed successfully", "subscriptions_processed", totalSubscriptions)

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -69,14 +69,18 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.isShuttingDown {
+		return fmt.Errorf("cannot subscribe to %s: repository is shutting down", subject)
+	}
+
 	r.logger.InfoContext(ctx, "Creating NATS subscription", "subject", subject)
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
-		r.sem <- struct{}{}
 		r.wg.Add(1)
+		r.sem <- struct{}{}
 		go func() {
 			defer func() {
 				<-r.sem
@@ -116,15 +120,19 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.isShuttingDown {
+		return fmt.Errorf("cannot queue subscribe to %s: repository is shutting down", subject)
+	}
+
 	r.logger.InfoContext(ctx, "Creating NATS queue subscription", "subject", subject, "queue", queue)
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
 		// Deep-copy message data before handing off to goroutine
 		data := append([]byte(nil), msg.Data...)
-		subject := msg.Subject
-		r.sem <- struct{}{}
+		msgSubject := msg.Subject
 		r.wg.Add(1)
+		r.sem <- struct{}{}
 		go func() {
 			defer func() {
 				<-r.sem
@@ -132,9 +140,9 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 			}()
 
 			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
-			logger.Debug("NATS queue message received", "subject", subject, "queue", queue, "size", len(data))
+			logger.Debug("NATS queue message received", "subject", msgSubject, "queue", queue, "size", len(data))
 
-			if err := handler.Handle(ctx, data, subject); err != nil {
+			if err := handler.Handle(ctx, data, msgSubject); err != nil {
 				logger.Error("Queue message handler failed", "queue", queue, "error", err.Error())
 			}
 		}()
@@ -164,6 +172,10 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	if r.isShuttingDown {
+		return fmt.Errorf("cannot queue subscribe with reply to %s: repository is shutting down", subject)
+	}
+
 	r.logger.InfoContext(ctx, "Creating NATS queue subscription with reply", "subject", subject, "queue", queue)
 
 	// Create the NATS message handler with reply support
@@ -173,8 +185,8 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 		msgSubject := msg.Subject
 		replySubject := msg.Reply
 
-		r.sem <- struct{}{}
 		r.wg.Add(1)
+		r.sem <- struct{}{}
 		go func() {
 			defer func() {
 				<-r.sem
@@ -300,8 +312,10 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 	}
 
 	// Wait for drain to complete
+	drainTimedOut := false
 	select {
 	case <-time.After(r.drainTimeout):
+		drainTimedOut = true
 		r.logger.Warn("NATS drain timeout reached", "timeout", r.drainTimeout)
 	case <-func() <-chan struct{} {
 		done := make(chan struct{})
@@ -313,13 +327,34 @@ func (r *MessagingRepository) DrainWithTimeout() error {
 		}()
 		return done
 	}():
-		// Drain completed successfully
+		// Drain completed before timeout
 	}
 
 	// Wait for all in-flight handler goroutines to finish, bounded by the
 	// remaining drain budget. Conn.Drain() only waits for callbacks to return,
 	// not for goroutines spawned inside them, so we track them with a WaitGroup.
-	r.waitForHandlers(time.Until(deadline))
+	handlersTimedOut := false
+	remaining := time.Until(deadline)
+	if remaining > 0 {
+		done := make(chan struct{})
+		go func() {
+			r.wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(remaining):
+			handlersTimedOut = true
+			r.logger.Warn("Timed out waiting for in-flight NATS handlers", "timeout", remaining)
+		}
+	} else {
+		r.logger.Warn("No time remaining to wait for in-flight NATS handlers")
+	}
+
+	if drainTimedOut || handlersTimedOut {
+		r.logger.Warn("NATS drain did not complete cleanly", "drain_timed_out", drainTimedOut, "handlers_timed_out", handlersTimedOut, "subscriptions_processed", totalSubscriptions)
+		return fmt.Errorf("NATS drain timed out after %s", r.drainTimeout)
+	}
 
 	r.logger.Info("NATS drain completed successfully", "subscriptions_processed", totalSubscriptions)
 	return nil

--- a/internal/infrastructure/messaging/messaging_repository_test.go
+++ b/internal/infrastructure/messaging/messaging_repository_test.go
@@ -10,13 +10,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/auth"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/auth"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 )
 
 // MockMessageHandler implements MessageHandler for testing

--- a/internal/infrastructure/messaging/messaging_repository_test.go
+++ b/internal/infrastructure/messaging/messaging_repository_test.go
@@ -49,7 +49,7 @@ func TestNewMessagingRepository(t *testing.T) {
 	drainTimeout := 10 * time.Second
 
 	t.Run("without_auth_repo", func(t *testing.T) {
-		repo := NewMessagingRepository(nil, nil, logger, drainTimeout)
+		repo := NewMessagingRepository(nil, nil, logger, drainTimeout, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 		assert.NotNil(t, repo)
 		assert.NotNil(t, repo.logger)
@@ -62,7 +62,7 @@ func TestNewMessagingRepository(t *testing.T) {
 
 func TestMessagingRepository_ValidateToken_NoAuthRepo(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	ctx := context.Background()
 	token := "test.jwt.token" // #nosec G101 - This is a test token, not a real secret
@@ -76,7 +76,7 @@ func TestMessagingRepository_ValidateToken_NoAuthRepo(t *testing.T) {
 
 func TestMessagingRepository_ParsePrincipals_NoAuthRepo(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	ctx := context.Background()
 	headers := map[string]string{
@@ -93,7 +93,7 @@ func TestMessagingRepository_ParsePrincipals_NoAuthRepo(t *testing.T) {
 
 func TestMessagingRepository_PublishDisconnected(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	ctx := context.Background()
 	subject := "test.subject"
@@ -107,7 +107,7 @@ func TestMessagingRepository_PublishDisconnected(t *testing.T) {
 
 func TestMessagingRepository_HealthCheck_NilConnection(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	ctx := context.Background()
 
@@ -120,7 +120,7 @@ func TestMessagingRepository_HealthCheck_NilConnection(t *testing.T) {
 
 func TestMessagingRepository_DrainWithTimeout_NilConnection(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	err := repo.DrainWithTimeout()
 
@@ -129,7 +129,7 @@ func TestMessagingRepository_DrainWithTimeout_NilConnection(t *testing.T) {
 
 func TestMessagingRepository_Close_NilConnection(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	err := repo.Close()
 
@@ -138,7 +138,7 @@ func TestMessagingRepository_Close_NilConnection(t *testing.T) {
 
 func TestMessagingRepository_UtilityMethods_NilConnection(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	t.Run("get_connection", func(t *testing.T) {
 		connection := repo.GetConnection()
@@ -193,7 +193,7 @@ func TestMessagingRepository_UtilityMethods_NilConnection(t *testing.T) {
 
 func TestMessagingRepository_PublicMethods(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	t.Run("connection_info", func(t *testing.T) {
 		// Test that GetConnection works with nil connection
@@ -237,7 +237,7 @@ func TestMessagingRepository_PublicMethods(t *testing.T) {
 
 func TestMessagingRepository_UtilityMethods(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	t.Run("metrics_structure", func(t *testing.T) {
 		// Test that metrics have expected structure
@@ -282,7 +282,7 @@ func TestMessagingRepository_UtilityMethods(t *testing.T) {
 
 func TestMessagingRepository_StateManagement(t *testing.T) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	t.Run("connection_info_nil_safe", func(t *testing.T) {
 		// Test that GetConnectionStatus handles nil connection gracefully
@@ -308,7 +308,7 @@ func TestMessagingRepository_StateManagement(t *testing.T) {
 // Performance benchmarks
 func BenchmarkMessagingRepository_PublicMethods(b *testing.B) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	b.Run("GetConnection", func(b *testing.B) {
 		b.ResetTimer()
@@ -334,7 +334,7 @@ func BenchmarkMessagingRepository_PublicMethods(b *testing.B) {
 
 func BenchmarkMessagingRepository_GetMetrics(b *testing.B) {
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -356,7 +356,7 @@ func TestMessagingRepository_IntegrationWithNATS(t *testing.T) {
 	defer conn.Close()
 
 	logger := setupTestLogger()
-	repo := NewMessagingRepository(conn, nil, logger, 5*time.Second)
+	repo := NewMessagingRepository(conn, nil, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 	defer repo.Close()
 
 	ctx := context.Background()
@@ -482,7 +482,7 @@ func TestMessagingRepository_WithAuthRepo(t *testing.T) {
 		t.Skipf("Skipping auth test: %v", err)
 	}
 
-	repo := NewMessagingRepository(nil, authRepo, logger, 5*time.Second)
+	repo := NewMessagingRepository(nil, authRepo, logger, 5*time.Second, constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit, constants.DefaultWorkerCount)
 	ctx := context.Background()
 
 	t.Run("validate_token_with_auth_repo", func(t *testing.T) {

--- a/internal/infrastructure/storage/storage_repository.go
+++ b/internal/infrastructure/storage/storage_repository.go
@@ -35,6 +35,16 @@ func NewStorageRepository(client *opensearch.Client, logger *slog.Logger) *Stora
 	}
 }
 
+// refreshValue returns the appropriate OpenSearch refresh parameter for ctx.
+// When the caller is waiting for an ACK (reply subject present), wait_for
+// blocks until the next refresh so the document is immediately searchable.
+func refreshValue(ctx context.Context) string {
+	if logging.NeedsRefreshWaitFor(ctx) {
+		return constants.RefreshWaitFor
+	}
+	return constants.RefreshFalse
+}
+
 // Index indexes a transaction body into OpenSearch
 func (r *StorageRepository) Index(ctx context.Context, index string, docID string, body io.Reader) error {
 	logger := logging.FromContext(ctx, r.logger)
@@ -44,7 +54,7 @@ func (r *StorageRepository) Index(ctx context.Context, index string, docID strin
 		Index:      index,
 		DocumentID: docID,
 		Body:       body,
-		Refresh:    constants.RefreshFalse,
+		Refresh:    refreshValue(ctx),
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -186,7 +196,7 @@ func (r *StorageRepository) Update(ctx context.Context, index string, docID stri
 		Index:      index,
 		DocumentID: docID,
 		Body:       body,
-		Refresh:    constants.RefreshFalse,
+		Refresh:    refreshValue(ctx),
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -220,7 +230,7 @@ func (r *StorageRepository) Delete(ctx context.Context, index string, docID stri
 	req := opensearchapi.DeleteRequest{
 		Index:      index,
 		DocumentID: docID,
-		Refresh:    constants.RefreshFalse,
+		Refresh:    refreshValue(ctx),
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -369,7 +379,7 @@ func (r *StorageRepository) UpdateWithOptimisticLock(ctx context.Context, index,
 		Index:      index,
 		DocumentID: docID,
 		Body:       body,
-		Refresh:    constants.RefreshFalse,
+		Refresh:    refreshValue(ctx),
 	}
 
 	// Add optimistic concurrency control parameters if provided

--- a/internal/infrastructure/storage/storage_repository.go
+++ b/internal/infrastructure/storage/storage_repository.go
@@ -13,11 +13,12 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/opensearch-project/opensearch-go/v2"
+	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
+
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
-	"github.com/opensearch-project/opensearch-go/v2"
-	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
 )
 
 // StorageRepository implements the domain StorageRepository interface
@@ -43,7 +44,7 @@ func (r *StorageRepository) Index(ctx context.Context, index string, docID strin
 		Index:      index,
 		DocumentID: docID,
 		Body:       body,
-		Refresh:    constants.RefreshTrue,
+		Refresh:    constants.RefreshFalse,
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -185,7 +186,7 @@ func (r *StorageRepository) Update(ctx context.Context, index string, docID stri
 		Index:      index,
 		DocumentID: docID,
 		Body:       body,
-		Refresh:    constants.RefreshTrue,
+		Refresh:    constants.RefreshFalse,
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -219,7 +220,7 @@ func (r *StorageRepository) Delete(ctx context.Context, index string, docID stri
 	req := opensearchapi.DeleteRequest{
 		Index:      index,
 		DocumentID: docID,
-		Refresh:    constants.RefreshTrue,
+		Refresh:    constants.RefreshFalse,
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -290,7 +291,7 @@ func (r *StorageRepository) BulkIndex(ctx context.Context, operations []contract
 
 	req := opensearchapi.BulkRequest{
 		Body:    &buf,
-		Refresh: constants.RefreshTrue,
+		Refresh: constants.RefreshFalse,
 	}
 
 	res, err := req.Do(ctx, r.client)
@@ -368,7 +369,7 @@ func (r *StorageRepository) UpdateWithOptimisticLock(ctx context.Context, index,
 		Index:      index,
 		DocumentID: docID,
 		Body:       body,
-		Refresh:    constants.RefreshTrue,
+		Refresh:    constants.RefreshFalse,
 	}
 
 	// Add optimistic concurrency control parameters if provided

--- a/internal/infrastructure/storage/storage_repository_test.go
+++ b/internal/infrastructure/storage/storage_repository_test.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 )
 
 // Helper function to create a test logger

--- a/internal/presentation/handlers/health_handler_test.go
+++ b/internal/presentation/handlers/health_handler_test.go
@@ -8,10 +8,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/services"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/mocks"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthHandler_HandleReadiness_Healthy(t *testing.T) {

--- a/internal/presentation/handlers/indexing_message_handler_test.go
+++ b/internal/presentation/handlers/indexing_message_handler_test.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
 )
 
 // MessageProcessorInterface defines the interface for message processing methods used by the handler

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -97,3 +97,10 @@ const (
 	RefreshFalse = "false" // OpenSearch refresh parameter
 	ReplyTimeout = 5 * time.Second
 )
+
+// NATS pending buffer and concurrency defaults
+const (
+	DefaultPendingMsgLimit   = 1_000_000         // 1M messages
+	DefaultPendingBytesLimit = 512 * 1024 * 1024 // 512 MiB
+	DefaultWorkerCount       = 100               // concurrent message handlers
+)

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -100,6 +100,11 @@ const (
 	// preferred setting for high-throughput writes where eventual consistency
 	// within 1s is acceptable.
 	RefreshFalse = "false"
+	// RefreshWaitFor blocks until the next refresh cycle completes before
+	// returning, making the document immediately searchable without forcing an
+	// extra segment flush. Used when the caller is waiting for an ACK (i.e.
+	// when a NATS reply subject is present).
+	RefreshWaitFor = "wait_for"
 	ReplyTimeout = 5 * time.Second
 )
 

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -105,12 +105,21 @@ const (
 	// extra segment flush. Used when the caller is waiting for an ACK (i.e.
 	// when a NATS reply subject is present).
 	RefreshWaitFor = "wait_for"
-	ReplyTimeout = 5 * time.Second
+	ReplyTimeout   = 5 * time.Second
 )
 
-// NATS pending buffer and concurrency defaults
+// NATS pending buffer and concurrency defaults.
+//
+// These pending limits are per subscription, not process-wide. In deployments
+// with multiple subscriptions in the same process (for example, V1 and V2
+// consumers together), the allowed in-memory backlog grows proportionally
+// across each subscription during downstream slowness.
+//
+// Treat these values as upper bounds that should be tuned to the memory
+// capacity and throughput characteristics of each deployment rather than as
+// universally safe defaults.
 const (
-	DefaultPendingMsgLimit   = 1_000_000         // 1M messages
-	DefaultPendingBytesLimit = 512 * 1024 * 1024 // 512 MiB
+	DefaultPendingMsgLimit   = 1_000_000         // Maximum pending messages per subscription; tune down for memory-constrained deployments.
+	DefaultPendingBytesLimit = 512 * 1024 * 1024 // Maximum pending bytes per subscription (512 MiB); tune based on aggregate process memory budget.
 	DefaultWorkerCount       = 100               // concurrent message handlers
 )

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -93,8 +93,13 @@ const (
 // Message processing constants
 const (
 	DefaultQueue = "lfx.indexer.queue"
-	RefreshTrue  = "true"  // OpenSearch refresh parameter
-	RefreshFalse = "false" // OpenSearch refresh parameter
+	RefreshTrue = "true" // OpenSearch refresh parameter — forces immediate segment refresh; use sparingly (high write latency)
+	// RefreshFalse defers refresh to the next scheduled interval (default 1s).
+	// Documents written with this setting are not immediately searchable — a
+	// subsequent read within ~1s may not return the new document. This is the
+	// preferred setting for high-throughput writes where eventual consistency
+	// within 1s is acceptable.
+	RefreshFalse = "false"
 	ReplyTimeout = 5 * time.Second
 )
 

--- a/pkg/constants/messaging.go
+++ b/pkg/constants/messaging.go
@@ -93,7 +93,7 @@ const (
 // Message processing constants
 const (
 	DefaultQueue = "lfx.indexer.queue"
-	RefreshTrue = "true" // OpenSearch refresh parameter — forces immediate segment refresh; use sparingly (high write latency)
+	RefreshTrue  = "true" // OpenSearch refresh parameter — forces immediate segment refresh; use sparingly (high write latency)
 	// RefreshFalse defers refresh to the next scheduled interval (default 1s).
 	// Documents written with this setting are not immediately searchable — a
 	// subsequent read within ~1s may not return the new document. This is the

--- a/pkg/constants/messaging_test.go
+++ b/pkg/constants/messaging_test.go
@@ -6,8 +6,9 @@ package constants_test
 import (
 	"testing"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 )
 
 func TestBuildEventSubject(t *testing.T) {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -18,8 +18,9 @@ import (
 type contextKey string
 
 const (
-	requestLoggerKey contextKey = "request_logger"
-	requestIDKey     contextKey = "request_id"
+	requestLoggerKey  contextKey = "request_logger"
+	requestIDKey      contextKey = "request_id"
+	refreshWaitForKey contextKey = "refresh_wait_for"
 )
 
 // NewRequestID generates a simple 16-character request ID
@@ -120,6 +121,19 @@ func FromContext(ctx context.Context, fallback *slog.Logger) *slog.Logger {
 // WithComponent adds component field to logger
 func WithComponent(logger *slog.Logger, component string) *slog.Logger {
 	return logger.With("component", component)
+}
+
+// WithRefreshWaitFor marks the context to indicate the caller is waiting for
+// an ACK (NATS reply subject present). Storage operations should use
+// refresh=wait_for so the document is immediately searchable on reply.
+func WithRefreshWaitFor(ctx context.Context) context.Context {
+	return context.WithValue(ctx, refreshWaitForKey, true)
+}
+
+// NeedsRefreshWaitFor reports whether the context was marked by WithRefreshWaitFor.
+func NeedsRefreshWaitFor(ctx context.Context) bool {
+	v, _ := ctx.Value(refreshWaitForKey).(bool)
+	return v
 }
 
 // WithOperation adds operation field to logger

--- a/scripts/migration/001_add_access_query_fields/main.go
+++ b/scripts/migration/001_add_access_query_fields/main.go
@@ -31,9 +31,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/env"
 	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/env"
 )
 
 // Config holds the migration configuration


### PR DESCRIPTION
## Summary

- Change OpenSearch `Refresh` from `true` to `false` to eliminate forced Lucene commits on every write (reduces per-write latency significantly)
- Add configurable NATS pending message/bytes limits via `NATS_PENDING_MSG_LIMIT` (default: 1M) and `NATS_PENDING_BYTES_LIMIT` (default: 512MiB) to increase the subscription buffer
- Add concurrent message dispatch with a bounded semaphore-based worker pool via `NATS_WORKER_COUNT` (default: 100) so the NATS dispatch goroutine is never blocked by OpenSearch roundtrips

## Test plan

- [ ] `make quality` passes (fmt, vet, lint, test)
- [ ] Deploy to staging and monitor Datadog for reduction in "nats: slow consumer, messages dropped" errors
- [ ] Confirm OpenSearch query results still reflect recent writes within ~1s (default refresh interval)
- [ ] Verify no increase in other error categories after deployment

## Related

JIRA: [LFXV2-1564](https://linuxfoundation.atlassian.net/browse/LFXV2-1564)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1564]: https://linuxfoundation.atlassian.net/browse/LFXV2-1564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ