### PR TITLE
[LFXV2-1565] fix: suppress log noise from unresolvable indexing_config templates

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -189,7 +190,7 @@ func (s *IndexerService) CreateTransactionFromMessage(messageData map[string]any
 			transactionData = make(map[string]any)
 		}
 
-		indexingConfig, err := s.parseIndexingConfig(indexingConfigData, transactionData)
+		indexingConfig, err := s.parseIndexingConfig(indexingConfigData, transactionData, objectType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse indexing_config: %w", err)
 		}
@@ -1352,15 +1353,15 @@ func (s *IndexerService) buildTransactionBodyFromIndexingConfig(
 // expandTemplates recursively expands template variables in the format {{ field_name }}
 // with values from the provided data map. Supports nested field access (e.g., {{ parent.id }})
 // and preserves original data types.
-func expandTemplates(data map[string]any, value any) (any, error) {
+func expandTemplates(data map[string]any, value any, objectType string) (any, error) {
 	switch v := value.(type) {
 	case string:
-		return expandTemplateString(data, v)
+		return expandTemplateString(data, v, objectType)
 	case []interface{}:
 		// Handle arrays - expand templates in each element
 		result := make([]interface{}, len(v))
 		for i, item := range v {
-			expanded, err := expandTemplates(data, item)
+			expanded, err := expandTemplates(data, item, objectType)
 			if err != nil {
 				return nil, err
 			}
@@ -1371,7 +1372,7 @@ func expandTemplates(data map[string]any, value any) (any, error) {
 		// Handle nested objects - expand templates in each value
 		result := make(map[string]interface{}, len(v))
 		for key, val := range v {
-			expanded, err := expandTemplates(data, val)
+			expanded, err := expandTemplates(data, val, objectType)
 			if err != nil {
 				return nil, err
 			}
@@ -1384,8 +1385,11 @@ func expandTemplates(data map[string]any, value any) (any, error) {
 	}
 }
 
-// expandTemplateString expands template variables in a string
-func expandTemplateString(data map[string]any, template string) (any, error) {
+// expandTemplateString expands template variables in a string.
+// If a referenced field is not present in data, the expansion is skipped (empty
+// string for whole-value templates, blank substitution for embedded ones) and a
+// warning is logged. Structural errors (e.g. traversing a non-object) are fatal.
+func expandTemplateString(data map[string]any, template string, objectType string) (any, error) {
 	// Check if this is an escaped template (e.g., \{{ field }})
 	if strings.Contains(template, "\\{{") {
 		// Remove escape characters
@@ -1398,6 +1402,15 @@ func expandTemplateString(data map[string]any, template string) (any, error) {
 		fieldPath := strings.TrimSpace(template[2 : len(template)-2])
 		value, err := getNestedField(data, fieldPath)
 		if err != nil {
+			if isFieldNotFoundError(err) {
+				// Upstream publishers (e.g. ONAP via groupsio_artifact) embed
+				// infrastructure-specific template vars that have no LFX data
+				// counterpart. Skip silently rather than dropping the document.
+				slog.Default().Warn("Skipping unresolvable template field",
+					"field", fieldPath,
+					"object_type", objectType)
+				return "", nil
+			}
 			return nil, err
 		}
 		// Return the original type
@@ -1415,6 +1428,13 @@ func expandTemplateString(data map[string]any, template string) (any, error) {
 
 		value, err := getNestedField(data, fieldPath)
 		if err != nil {
+			if isFieldNotFoundError(err) {
+				slog.Default().Warn("Skipping unresolvable template field",
+					"field", fieldPath,
+					"object_type", objectType)
+				result = strings.ReplaceAll(result, fullMatch, "")
+				continue
+			}
 			return nil, err
 		}
 
@@ -1439,6 +1459,20 @@ func expandTemplateString(data map[string]any, template string) (any, error) {
 	return result, nil
 }
 
+// errTemplateFieldNotFound is returned when a template references a key absent from
+// the data map. It is intentionally distinct from structural errors so callers can
+// choose to skip rather than fail.
+type errTemplateFieldNotFound struct{ field string }
+
+func (e *errTemplateFieldNotFound) Error() string {
+	return fmt.Sprintf("template field '%s' not found in data", e.field)
+}
+
+func isFieldNotFoundError(err error) bool {
+	var e *errTemplateFieldNotFound
+	return errors.As(err, &e)
+}
+
 // getNestedField retrieves a value from a nested map using dot notation
 // e.g., "parent.id" retrieves data["parent"]["id"]
 func getNestedField(data map[string]any, fieldPath string) (any, error) {
@@ -1453,7 +1487,7 @@ func getNestedField(data map[string]any, fieldPath string) (any, error) {
 
 		value, exists := currentMap[part]
 		if !exists {
-			return nil, fmt.Errorf("template field '%s' not found in data", fieldPath)
+			return nil, &errTemplateFieldNotFound{field: fieldPath}
 		}
 
 		current = value
@@ -1464,12 +1498,12 @@ func getNestedField(data map[string]any, fieldPath string) (any, error) {
 
 // parseIndexingConfig parses a map[string]any into a strongly-typed IndexingConfig struct
 // and expands any template variables using the provided transaction data.
-func (s *IndexerService) parseIndexingConfig(indexingConfigData map[string]any, transactionData map[string]any) (*types.IndexingConfig, error) {
+func (s *IndexerService) parseIndexingConfig(indexingConfigData map[string]any, transactionData map[string]any, objectType string) (*types.IndexingConfig, error) {
 	logger := s.logger
-	logger.Debug("Parsing indexing config", "indexing_config", indexingConfigData)
+	logger.Debug("Parsing indexing config", "indexing_config", indexingConfigData, "object_type", objectType)
 
 	// First, expand all templates in the indexing_config data
-	expandedData, err := expandTemplates(transactionData, indexingConfigData)
+	expandedData, err := expandTemplates(transactionData, indexingConfigData, objectType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand templates in indexing_config: %w", err)
 	}

--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -1353,15 +1353,15 @@ func (s *IndexerService) buildTransactionBodyFromIndexingConfig(
 // expandTemplates recursively expands template variables in the format {{ field_name }}
 // with values from the provided data map. Supports nested field access (e.g., {{ parent.id }})
 // and preserves original data types.
-func expandTemplates(data map[string]any, value any, objectType string) (any, error) {
+func expandTemplates(data map[string]any, value any, objectType string, logger *slog.Logger) (any, error) {
 	switch v := value.(type) {
 	case string:
-		return expandTemplateString(data, v, objectType)
+		return expandTemplateString(data, v, objectType, logger)
 	case []interface{}:
 		// Handle arrays - expand templates in each element
 		result := make([]interface{}, len(v))
 		for i, item := range v {
-			expanded, err := expandTemplates(data, item, objectType)
+			expanded, err := expandTemplates(data, item, objectType, logger)
 			if err != nil {
 				return nil, err
 			}
@@ -1372,7 +1372,7 @@ func expandTemplates(data map[string]any, value any, objectType string) (any, er
 		// Handle nested objects - expand templates in each value
 		result := make(map[string]interface{}, len(v))
 		for key, val := range v {
-			expanded, err := expandTemplates(data, val, objectType)
+			expanded, err := expandTemplates(data, val, objectType, logger)
 			if err != nil {
 				return nil, err
 			}
@@ -1389,7 +1389,7 @@ func expandTemplates(data map[string]any, value any, objectType string) (any, er
 // If a referenced field is not present in data, the expansion is skipped (empty
 // string for whole-value templates, blank substitution for embedded ones) and a
 // warning is logged. Structural errors (e.g. traversing a non-object) are fatal.
-func expandTemplateString(data map[string]any, template string, objectType string) (any, error) {
+func expandTemplateString(data map[string]any, template string, objectType string, logger *slog.Logger) (any, error) {
 	// Check if this is an escaped template (e.g., \{{ field }})
 	if strings.Contains(template, "\\{{") {
 		// Remove escape characters
@@ -1403,10 +1403,10 @@ func expandTemplateString(data map[string]any, template string, objectType strin
 		value, err := getNestedField(data, fieldPath)
 		if err != nil {
 			if isFieldNotFoundError(err) {
-				// Upstream publishers (e.g. ONAP via groupsio_artifact) embed
-				// infrastructure-specific template vars that have no LFX data
-				// counterpart. Skip silently rather than dropping the document.
-				slog.Default().Warn("Skipping unresolvable template field",
+				// Upstream publishers embed infrastructure-specific template vars
+				// that have no LFX data counterpart. Warn and skip expansion
+				// rather than dropping the document.
+				logger.Warn("Skipping unresolvable template field",
 					"field", fieldPath,
 					"object_type", objectType)
 				return "", nil
@@ -1429,7 +1429,7 @@ func expandTemplateString(data map[string]any, template string, objectType strin
 		value, err := getNestedField(data, fieldPath)
 		if err != nil {
 			if isFieldNotFoundError(err) {
-				slog.Default().Warn("Skipping unresolvable template field",
+				logger.Warn("Skipping unresolvable template field",
 					"field", fieldPath,
 					"object_type", objectType)
 				result = strings.ReplaceAll(result, fullMatch, "")
@@ -1503,7 +1503,7 @@ func (s *IndexerService) parseIndexingConfig(indexingConfigData map[string]any, 
 	logger.Debug("Parsing indexing config", "indexing_config", indexingConfigData, "object_type", objectType)
 
 	// First, expand all templates in the indexing_config data
-	expandedData, err := expandTemplates(transactionData, indexingConfigData, objectType)
+	expandedData, err := expandTemplates(transactionData, indexingConfigData, objectType, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand templates in indexing_config: %w", err)
 	}

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -492,7 +492,7 @@ func TestIndexerService_parseIndexingConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Pass empty transaction data for backward compatibility tests
-			config, err := service.parseIndexingConfig(tt.input, map[string]any{})
+			config, err := service.parseIndexingConfig(tt.input, map[string]any{}, "test_object")
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -654,7 +654,7 @@ func TestIndexerService_parseIndexingConfig_TemplateExpansion(t *testing.T) {
 				"uid": "proj-123",
 			},
 			wantErr:     true,
-			errContains: "template field 'missing_field' not found in data",
+			errContains: "object_id is required and must be a non-empty string",
 		},
 		{
 			name: "invalid nested field path should error",
@@ -837,7 +837,7 @@ func TestIndexerService_parseIndexingConfig_TemplateExpansion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := service.parseIndexingConfig(tt.indexingConfig, tt.transactionData)
+			config, err := service.parseIndexingConfig(tt.indexingConfig, tt.transactionData, "test_object")
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -657,6 +657,25 @@ func TestIndexerService_parseIndexingConfig_TemplateExpansion(t *testing.T) {
 			errContains: "object_id is required and must be a non-empty string",
 		},
 		{
+			name: "missing template field in optional embedded string should succeed",
+			indexingConfig: map[string]any{
+				"object_id":              "{{ uid }}",
+				"access_check_object":    "project:{{ uid }}",
+				"access_check_relation":  "viewer",
+				"history_check_object":   "project:{{ uid }}",
+				"history_check_relation": "historian",
+				"fulltext":               "{{ name }} - {{ missing_field }}",
+			},
+			transactionData: map[string]any{
+				"uid":  "proj-123",
+				"name": "Test Project",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, config *types.IndexingConfig) {
+				assert.Equal(t, "Test Project - ", config.Fulltext)
+			},
+		},
+		{
 			name: "invalid nested field path should error",
 			indexingConfig: map[string]any{
 				"object_id":              "{{ uid }}",


### PR DESCRIPTION
## Summary

- When a template field (e.g. `{{ controllerHost }}`) is not found in the transaction data, treat it as non-fatal: log a `WARN` with the field name and `object_type`, and skip the replacement rather than failing the entire indexing operation
- Structural template errors (malformed `{{ }}` syntax) remain fatal and propagate as before
- Threads `objectType` through `parseIndexingConfig` → `expandTemplates` → `expandTemplateString` to include it in warning logs

## Test plan

- [ ] `make quality` passes (fmt, vet, lint, test)
- [ ] Deploy to staging and confirm "failed to expand templates in indexing_config" errors are replaced by WARN-level log lines
- [ ] Confirm affected object types (e.g. those with infrastructure-style template vars) are still indexed successfully

## Related

JIRA: [LFXV2-1565](https://linuxfoundation.atlassian.net/browse/LFXV2-1565)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1565]: https://linuxfoundation.atlassian.net/browse/LFXV2-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ