### PR TITLE
[LFXV2-1701] fix: downgrade health check poll logs from error to warn

### DIFF
--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -461,20 +461,20 @@ func (r *MessagingRepository) HealthCheck(ctx context.Context) error {
 
 	// Check basic connection state
 	if r.conn == nil {
-		r.logger.Error("NATS health check failed: connection is nil")
+		r.logger.Warn("NATS health check failed: connection is nil")
 		return fmt.Errorf("%s: NATS connection is nil", constants.ErrHealthCheck)
 	}
 
 	r.logger.Debug("NATS connection diagnostics", "status", r.conn.Status().String(), "connected", r.conn.IsConnected())
 
 	if !r.conn.IsConnected() {
-		r.logger.Error("NATS health check failed: connection not connected", "status", r.conn.Status().String())
+		r.logger.Warn("NATS health check failed: connection not connected", "status", r.conn.Status().String())
 		return fmt.Errorf("%s: NATS connection is not connected", constants.ErrHealthCheck)
 	}
 
 	// Check if we can get server info
 	if r.conn.Status() != nats.CONNECTED {
-		r.logger.Error("NATS health check failed: connection status not connected",
+		r.logger.Warn("NATS health check failed: connection status not connected",
 			"status", r.conn.Status().String(),
 			"expected", nats.CONNECTED.String())
 		return fmt.Errorf("%s: NATS connection status is not connected: %s", constants.ErrHealthCheck, r.conn.Status())

--- a/internal/infrastructure/storage/storage_repository.go
+++ b/internal/infrastructure/storage/storage_repository.go
@@ -431,13 +431,13 @@ func (r *StorageRepository) HealthCheck(ctx context.Context) error {
 
 	res, err := req.Do(ctx, r.client)
 	if err != nil {
-		logger.Error("Failed to execute health check request", "error", err.Error())
+		logger.Warn("OpenSearch health check failed", "error", err.Error())
 		return fmt.Errorf("%s: %w", constants.ErrHealthCheck, err)
 	}
 	defer res.Body.Close()
 
 	if res.IsError() {
-		logger.Error("Health check request failed", "status", res.Status())
+		logger.Warn("OpenSearch health check returned error status", "status", res.Status())
 		return fmt.Errorf("%s: %s", constants.ErrHealthCheck, res.Status())
 	}
 


### PR DESCRIPTION
## Summary

- Downgrade NATS health check log messages from `Error` to `Warn` in `messaging_repository.go` — these fire on every K8s probe poll (~10s) during a degraded state, flooding logs with repeated errors
- Rename and downgrade OpenSearch health check log messages from `Error` to `Warn` in `storage_repository.go`, adding "OpenSearch" context to the message so the failing dependency is unambiguous
- One-time lifecycle events (e.g. `NATS connection permanently closed - max reconnects exhausted`) remain at `Error` since they fire once and identify the root cause

## Ticket

[LFXV2-1701](https://linuxfoundation.atlassian.net/browse/LFXV2-1701)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1701]: https://linuxfoundation.atlassian.net/browse/LFXV2-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ