### PR TITLE
docs: repo-owned indexer contract and dev guidance (LFXV2-2015)

### DIFF
--- a/.claude/rules/indexer-contract.md
+++ b/.claude/rules/indexer-contract.md
@@ -1,0 +1,17 @@
+---
+description: Indexer contract policy for action constants, envelope shape, and OpenSearch field coordination
+paths:
+  - 'internal/domain/contracts/**'
+  - 'internal/domain/services/indexer_service.go'
+  - 'internal/infrastructure/storage/**'
+  - 'pkg/types/**'
+  - 'pkg/constants/**'
+  - 'docs/indexer-contract.md'
+---
+
+# Indexer contract policy
+
+- Use action constants from `pkg/constants`. Never inline string literals for action values at call sites.
+- Do not mutate existing envelope fields in place. Add new fields additively and version the envelope when shape changes.
+- Do not introduce new top-level OpenSearch fields without coordinating with `lfx-v2-query-service`, which owns the read-side schema.
+- The canonical indexer contract lives in `lfx-v2-indexer-service/docs/indexer-contract.md`. Treat that document as the source of truth for envelope, actions, and field semantics.

--- a/.claude/skills/indexer-publishing/SKILL.md
+++ b/.claude/skills/indexer-publishing/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: indexer-publishing
+description: >
+  Use for any change on the indexer write path: a resource service emitting to
+  the LFX indexer (`lfx.index.<resource_type>`; consumed by `lfx.index.>`),
+  building or changing an
+  `IndexerMessageEnvelope`, touching `IndexingConfig`, modifying OpenSearch
+  document fields, or editing the indexer's own ingestion code
+  (`internal/domain/services/indexer_service.go`,
+  `internal/application/message_processor.go`). Read access (querying) is
+  owned by `lfx-v2-query-service`, not this skill.
+allowed-tools: Read, Glob, Grep, Edit
+paths:
+  - 'internal/domain/**'
+  - 'internal/application/**'
+  - 'internal/presentation/**'
+  - 'pkg/constants/**'
+  - 'docs/indexer-contract.md'
+  - 'docs/client-guide.md'
+---
+
+# Indexer Publishing
+
+The indexer is generic. Publishers tell it everything via the envelope. Follow this workflow for any change that touches the contract.
+
+## Workflow
+
+1. **Read the authoritative contract** in
+   `references/indexer-patterns.md` (link to
+   `docs/indexer-contract.md`). Confirm the change does not
+   introduce a new top-level OpenSearch field, rename an existing one, or
+   change the `IndexingConfig` shape.
+2. **Identify the publisher** (usually a resource service's
+   `internal/infrastructure/nats/messaging_publish.go` or equivalent). For
+   indexer-internal changes, the source is `internal/domain/services/` and
+   `internal/application/message_processor.go`.
+3. **Validate the envelope** every call path produces:
+   - `Action` uses a `constants.Action*` constant, never a string literal.
+   - `Headers` carries lower-case `authorization` and `x-on-behalf-of` keys
+     from request context.
+   - `Data` is the full resource on create/update, the bare UID string on
+     delete.
+   - Create/update messages include a non-nil `IndexingConfig` that populates `ObjectID`,
+     `AccessCheckObject`, `AccessCheckRelation`, `HistoryCheckObject`, and
+     `HistoryCheckRelation`. Otherwise the indexer rejects the message while
+     parsing `IndexingConfig`.
+4. **Choose the right search field** for new attributes per the table in
+   `references/indexer-patterns.md` (`NameAndAliases`, `Tags`, `Fulltext`).
+   Adding new keys inside `data` requires no schema change.
+5. **For deletes**, send `Action = ActionDeleted` and `Data` = the UID
+   string. The handler will reject a full-resource delete.
+6. **Update the per-service contract doc** at `docs/indexer-contract.md` in
+   the owning service in the same PR as the publisher change.
+7. **For indexer-internal changes**, ensure NATS replies remain `"OK"` on
+   success and `"ERROR: <details>"` on failure, and that domain events on
+   `lfx.{object_type}.{action}` continue to fire after every successful
+   OpenSearch write.
+8. **Schema evolution**: adding a top-level OpenSearch field is breaking.
+   Coordinate with the query-service team and the indexer contract owner before
+   changing storage or publisher code.
+
+## Anti-patterns
+
+- Hardcoded subject strings outside `pkg/constants/`.
+- Sending `IndexingConfig: nil` and expecting the indexer to fill defaults.
+- Mixing V1 (`lfx.v1.index.>`, present-tense actions) and V2 (`lfx.index.>`,
+  past-tense actions) handler logic.
+- Writing OpenSearch documents directly from a publisher. Indexer-service owns
+  current-document writes under the `object_ref` document ID and emits the
+  post-index domain event.
+
+## References
+
+- `references/indexer-patterns.md`: the authoritative event contract.

--- a/.claude/skills/indexer-publishing/references/indexer-patterns.md
+++ b/.claude/skills/indexer-publishing/references/indexer-patterns.md
@@ -1,0 +1,9 @@
+# Indexer Patterns Reference
+
+This skill's reference content lives in the repo-owned canonical doc:
+
+`../../../../docs/indexer-contract.md`
+
+Read that file for the full envelope, `IndexingConfig` fields, OpenSearch
+document shape, rejection conditions, schema evolution policy, and publisher
+validation checklist.

--- a/.claude/skills/indexer-service-dev/SKILL.md
+++ b/.claude/skills/indexer-service-dev/SKILL.md
@@ -60,7 +60,7 @@ Rules:
 - Subscribe via the repo's `MessagingRepository` interface (`internal/infrastructure/messaging/`). Do not call the raw NATS client from handlers or services.
 - Both V2 (`lfx.index.>`) and V1 (`lfx.v1.index.>`) subjects bind to the same queue group `lfx.indexer.queue` so only one replica processes each message when scaled horizontally.
 - Subject prefix selects the version. Route on prefix in the handler, not on payload sniffing.
-- Reply on every message: `"OK"` on success, `"ERROR: <details>"` on failure. Reply is mandatory even for fire-and-forget publishers so they can detect handler failure.
+- Reply only when the incoming message includes a reply subject (request/reply): `"OK"` on success, `"ERROR: <details>"` on failure. A plain `Publish` with no reply inbox receives no reply. The handler builds a reply func only when `msg.Reply` is non-empty (see `internal/infrastructure/messaging/messaging_repository.go`).
 - Drain NATS connections during graceful shutdown through the existing shutdown path in `cmd/lfx-indexer/main.go`. Do not bypass it.
 - Subject strings live in `pkg/constants/` or runtime config. Never hardcode `lfx.index.>`, `lfx.v1.index.>`, or `lfx.{object_type}.{action}` at call sites.
 

--- a/.claude/skills/indexer-service-dev/SKILL.md
+++ b/.claude/skills/indexer-service-dev/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: indexer-service-dev
+description: Auto-attaches when editing Go code in lfx-v2-indexer-service. Owns repo-local Go conventions for this Clean Architecture NATS consumer that writes OpenSearch documents and emits domain events. Covers layer boundaries, the logging wrapper, NATS subscriber and OpenSearch storage patterns, mocks layout, layer-specific test targets, license headers, formatter, and linter. Does not own the indexer event contract (see `docs/indexer-contract.md` and the `indexer-contract` rule) or cross-repo platform topology (see `/lfx-skills:lfx-platform-architecture`).
+paths:
+  - "**/*.go"
+  - "go.mod"
+  - "go.sum"
+  - "Makefile"
+  - "cmd/**"
+  - "internal/**"
+  - "pkg/**"
+  - ".claude/skills/indexer-service-dev/**"
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# Development Conventions (lfx-v2-indexer-service)
+
+Repo-local Go conventions for the indexer service. This service consumes NATS index messages on `lfx.index.>` (V2) and `lfx.v1.index.>` (V1), writes documents into OpenSearch, and emits domain events on `lfx.{object_type}.{action}`. Conventions below apply to this repo's own Go code.
+
+## What this skill owns vs. routes elsewhere
+
+- This skill: how Go files in `cmd/`, `internal/`, and `pkg/` should be structured here.
+- `docs/indexer-contract.md` (in this repo): authoritative event contract (envelope, `IndexingConfig`, OpenSearch document shape, schema evolution). Other services link here.
+- `.claude/rules/indexer-contract.md` (in this repo): enforced contract policy on contract-sensitive paths (action constants, additive envelope changes, no new top-level OpenSearch fields without coordination).
+- `.claude/skills/indexer-publishing/SKILL.md` (in this repo): publisher workflow used by both indexer-internal changes and by resource services that emit index events.
+- `/lfx-skills:lfx-platform-architecture`: platform composition, V2 service classes, cross-service handoffs, NATS/KV ownership at the platform level.
+- `/lfx-skills:lfx`: cross-repo routing and "where does X live".
+
+## Clean Architecture layers (dependency rule: inner cannot import outer)
+
+| Layer | Path | Holds |
+|---|---|---|
+| Domain | `internal/domain/` | Pure business logic; entities in `contracts/` (`LFXTransaction`, `TransactionBody`, `IndexingEvent`); core service in `services/indexer_service.go`. Note: `IndexerMessageEnvelope` and `IndexingConfig` live in `pkg/types/indexing_config.go` (public client surface) and are imported by `contracts/transaction.go`. |
+| Application | `internal/application/` | Use-case orchestration. `message_processor.go` coordinates V2 and V1 workflows. |
+| Infrastructure | `internal/infrastructure/` | Adapters: `messaging/` (NATS client + queue groups), `storage/` (OpenSearch), `auth/` (Heimdall JWT), `cleanup/` (background janitor), `config/`. |
+| Presentation | `internal/presentation/handlers/` | Protocol concerns: `indexing_message_handler.go`, `health_handler.go`. |
+
+Rules:
+
+- `internal/domain/**` must not import `internal/infrastructure/**` or `internal/presentation/**`.
+- External systems are reached only through interfaces declared in `internal/domain/contracts/`.
+- Dependency injection lives in `cmd/lfx-indexer/main.go` (and the wiring in `internal/container/`). No global singletons.
+- Place new business logic in domain services; place new transport wiring in presentation; place new external adapters in infrastructure.
+
+## Generated code and contracts
+
+- This repo has no `gen/` or `api/` directory (not a Goa service). Do not introduce one.
+- Treat `internal/domain/contracts/`, `pkg/types/`, and OpenSearch document-building code as contract surfaces. The `indexer-contract` rule auto-attaches there and forbids inline action strings, in-place envelope mutation, and unilateral new top-level OpenSearch fields. Use the constants in `pkg/constants/`.
+- When the envelope or document shape changes, update `docs/indexer-contract.md` in the same PR. Publishers across the platform read it.
+
+## Logging
+
+- Use the repo wrapper in `pkg/logging/` (built on `log/slog`). Do not call `fmt.Println`, `fmt.Printf`, `log.Print*`, or `log.Println` for runtime logging.
+- Include stable structured fields when available: `request_id`, `principal`, `subject`, `object_type`, `object_id`, `action`, `message_id`, `operation`.
+- Do not log tokens, bearer headers, JWT contents, private keys, or raw payloads that may contain PII.
+- Honor `LOG_LEVEL` (set via env, e.g. `LOG_LEVEL=debug make run`).
+
+## NATS subscriber patterns (this consumer)
+
+- Subscribe via the repo's `MessagingRepository` interface (`internal/infrastructure/messaging/`). Do not call the raw NATS client from handlers or services.
+- Both V2 (`lfx.index.>`) and V1 (`lfx.v1.index.>`) subjects bind to the same queue group `lfx.indexer.queue` so only one replica processes each message when scaled horizontally.
+- Subject prefix selects the version. Route on prefix in the handler, not on payload sniffing.
+- Reply on every message: `"OK"` on success, `"ERROR: <details>"` on failure. Reply is mandatory even for fire-and-forget publishers so they can detect handler failure.
+- Drain NATS connections during graceful shutdown through the existing shutdown path in `cmd/lfx-indexer/main.go`. Do not bypass it.
+- Subject strings live in `pkg/constants/` or runtime config. Never hardcode `lfx.index.>`, `lfx.v1.index.>`, or `lfx.{object_type}.{action}` at call sites.
+
+For the consumer subjects, queue group, and outbound event semantics in one place, see `references/nats-messaging.md`.
+
+## OpenSearch storage patterns
+
+- Storage logic lives in `internal/infrastructure/storage/`. Domain services depend on the storage repository interface, not on the OpenSearch client directly.
+- The current write path calls `StorageRepository.Index` with `object_ref` as the OpenSearch document ID and `latest: true`. The background janitor (`internal/infrastructure/cleanup/`) reconciles duplicate `latest: true` hits for the same `object_ref` by flipping older hits to `latest: false`. Queries filter `latest: true`.
+- Top-level document fields and their sources are fixed by the contract document. Do not add a new top-level field in this repo's storage code without updating `docs/indexer-contract.md` and coordinating with `lfx-v2-query-service`.
+- `data` is `flat_object`. New keys inside `data` are free. Search-shaped fields (`name_and_aliases`, `tags`, `fulltext`, `sort_name`, `parent_refs`) come from `IndexingConfig`.
+
+## Domain events (outbound)
+
+- After every successful OpenSearch write, publish `lfx.{object_type}.{action}` with the `IndexingEvent` payload from `internal/domain/contracts/events.go`.
+- Publish failures here are non-blocking: log the error, do not fail the OpenSearch write path.
+- The full envelope, payload, and subscription rules are documented in `docs/indexer-contract.md`.
+
+## Authentication
+
+- V2 messages carry a JWT in the lower-case `authorization` header key validated against Heimdall (`internal/infrastructure/auth/`).
+- V1 messages carry `x-username` and `x-email` headers.
+- `x-on-behalf-of` is supported for delegation. Forward it through context.
+- Middleware (the handler layer) owns auth extraction. Service-layer code should not read headers directly; it reads from request context via typed keys.
+
+## Errors
+
+- Use the existing domain error type and helper constructors. Do not introduce a parallel sentinel-error family.
+- Wrap upstream errors so `errors.Is` and `errors.Unwrap` still work.
+- Translate domain errors to NATS reply strings (`"OK"` or `"ERROR: <details>"`) at the handler boundary, not in domain services.
+
+## Tests
+
+- Co-locate `*_test.go` files with the code under test.
+- Depend on interfaces for external systems: messaging, storage, auth, ID mappers. Mocks live in `internal/mocks/`. Add new mocks there.
+- Use table-driven tests for branching behavior; prefer one test function per exported method with cases in the table.
+- Test both V2 and V1 message formats wherever the code path differs.
+- Run the appropriate layer-specific target during development; run `make test` (race detection + coverage) before handoff.
+
+| Target | Scope |
+|---|---|
+| `make test-domain` | Business logic in `internal/domain/`. |
+| `make test-application` | Workflow coordination in `internal/application/`. |
+| `make test-infrastructure` | External adapters in `internal/infrastructure/`. |
+| `make test-presentation` | Handlers in `internal/presentation/`. |
+| `make test` | All of the above, race detection, coverage. |
+
+## Formatting, linting, license headers
+
+- Run `make fmt` (gofmt + goimports) and `make lint` (`golangci-lint`, configured in `.revive.toml` and the linter setup) before committing Go changes.
+- `make quality` runs fmt, vet, lint, and test together. Prefer it for pre-PR checks.
+- New Go files must carry the existing license header (Copyright The Linux Foundation, SPDX `MIT`). Check an existing sibling file for the exact format.
+- Document exported Go symbols when the linter requires it. Implementation comments only where the code is not self-explanatory.
+- Update repo-owned docs and contracts in the same PR as code that changes behavior.
+
+## References
+
+- `references/go-development-conventions.md` (~70 lines): condensed Go conventions checklist for quick review.
+- `references/nats-messaging.md` (~40 lines): indexer consumer subjects, queue group, reply contract, and outbound event subject pattern.

--- a/.claude/skills/indexer-service-dev/references/go-development-conventions.md
+++ b/.claude/skills/indexer-service-dev/references/go-development-conventions.md
@@ -26,7 +26,7 @@ Quick checklist form. The narrative lives in `../SKILL.md`. Use this file in a c
 
 ## NATS handler
 
-- [ ] Replies `"OK"` on success, `"ERROR: <details>"` on failure for every message.
+- [ ] Replies `"OK"` on success, `"ERROR: <details>"` on failure when the message carries a reply subject; no reply is sent for a plain publish.
 - [ ] Routes on subject prefix to pick V2 vs V1, not on payload sniffing.
 - [ ] V2 and V1 subscriptions both bind to `lfx.indexer.queue`.
 - [ ] Connection drain runs through the existing shutdown path; no ad-hoc `nc.Close()`.

--- a/.claude/skills/indexer-service-dev/references/go-development-conventions.md
+++ b/.claude/skills/indexer-service-dev/references/go-development-conventions.md
@@ -1,0 +1,70 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Go Conventions Checklist (lfx-v2-indexer-service)
+
+Quick checklist form. The narrative lives in `../SKILL.md`. Use this file in a code review pass.
+
+## Layer boundaries
+
+- [ ] No import from `internal/domain/**` into `internal/infrastructure/**` or `internal/presentation/**`.
+- [ ] External systems (NATS, OpenSearch, Heimdall) reached only through interfaces in `internal/domain/contracts/`.
+- [ ] New external adapters land in `internal/infrastructure/<adapter>/`.
+- [ ] Dependency injection edits stay in `cmd/lfx-indexer/main.go` and `internal/container/`.
+
+## Contracts and constants
+
+- [ ] No inline action string literals. Use `pkg/constants/` (`ActionCreated`, `ActionUpdated`, `ActionDeleted`).
+- [ ] No new top-level OpenSearch field or in-place envelope mutation without updating `docs/indexer-contract.md` and coordinating with `lfx-v2-query-service`.
+- [ ] Subject strings (`lfx.index.>`, `lfx.v1.index.>`, `lfx.{object_type}.{action}`) live in `pkg/constants/` or runtime config.
+
+## Logging
+
+- [ ] Uses `pkg/logging/` wrapper. No `fmt.Println`, `fmt.Printf`, `log.Print*`, or `log.Println` in runtime paths.
+- [ ] Includes stable fields where available: `request_id`, `principal`, `subject`, `object_type`, `object_id`, `action`, `message_id`, `operation`.
+- [ ] Never logs JWTs, bearer headers, secrets, or raw payloads that may contain PII.
+
+## NATS handler
+
+- [ ] Replies `"OK"` on success, `"ERROR: <details>"` on failure for every message.
+- [ ] Routes on subject prefix to pick V2 vs V1, not on payload sniffing.
+- [ ] V2 and V1 subscriptions both bind to `lfx.indexer.queue`.
+- [ ] Connection drain runs through the existing shutdown path; no ad-hoc `nc.Close()`.
+
+## OpenSearch storage
+
+- [ ] Storage code goes through the storage repository interface, not the OpenSearch client directly.
+- [ ] Indexer writes go through `StorageRepository.Index` with `object_ref` as the OpenSearch document ID and `latest: true`.
+- [ ] Search-shaped fields come from `IndexingConfig`. New keys inside `data` are free; new top-level fields are not.
+
+## Domain events
+
+- [ ] After every successful write, publish `lfx.{object_type}.{action}` with `IndexingEvent` from `internal/domain/contracts/events.go`.
+- [ ] Publish failures are logged but never fail the OpenSearch write path.
+
+## Auth
+
+- [ ] Handler layer extracts auth headers. Domain services read from request context only, never headers directly.
+- [ ] V1 paths handle `x-username` / `x-email`; V2 paths validate JWT via Heimdall.
+- [ ] `x-on-behalf-of` is forwarded through context.
+
+## Errors
+
+- [ ] Uses the existing domain error type and helpers. No parallel sentinel-error family.
+- [ ] Wraps upstream errors so `errors.Is` and `errors.Unwrap` still work.
+- [ ] Translates errors to NATS reply at the handler boundary, not in domain services.
+
+## Tests
+
+- [ ] `*_test.go` co-located with the code under test.
+- [ ] Mocks live in `internal/mocks/`.
+- [ ] Table-driven tests for branching behavior.
+- [ ] Both V2 and V1 covered where the path diverges.
+- [ ] Layer-specific target runs clean: `make test-domain`, `make test-application`, `make test-infrastructure`, `make test-presentation`. `make test` clean before handoff.
+
+## Formatting, lint, headers
+
+- [ ] `make fmt` and `make lint` clean. Prefer `make quality` pre-PR.
+- [ ] New Go files carry the Copyright + SPDX `MIT` header.
+- [ ] Exported symbols documented where the linter requires it.
+- [ ] Repo-owned docs and contracts updated in the same PR as behavior changes.

--- a/.claude/skills/indexer-service-dev/references/nats-messaging.md
+++ b/.claude/skills/indexer-service-dev/references/nats-messaging.md
@@ -26,8 +26,9 @@ subjects and the queue group are overridable via `NATS_INDEXING_SUBJECT`,
 
 ## Reply and outbound events
 
-- Reply: `"OK"` on success, `"ERROR: <details>"` on failure. Replies are required
-  even for fire-and-forget publishers so they can detect handler failure.
+- Reply: `"OK"` on success, `"ERROR: <details>"` on failure, sent only when the
+  message includes a reply subject (request/reply). A plain `Publish` with no reply
+  inbox receives no reply, so use request/reply to detect handler failure.
 - After every successful OpenSearch write the service publishes a domain event
   on `lfx.{object_type}.{action}` (e.g. `lfx.project.created`). Publish errors
   are non-blocking. See `internal/domain/contracts/events.go` for the

--- a/.claude/skills/indexer-service-dev/references/nats-messaging.md
+++ b/.claude/skills/indexer-service-dev/references/nats-messaging.md
@@ -1,0 +1,39 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# NATS Messaging (indexer-service consumer)
+
+**Read first:** `/lfx-skills:lfx-platform-architecture` for NATS/KV ownership
+and platform handoff context, then path-scoped `indexer-service-dev` guidance for NATS
+coding conventions. The notes below cover only what is specific to
+indexer-service as the consumer of index events and the emitter of domain
+events.
+
+## indexer-service subscriptions
+
+The indexer subscribes with a single wildcard per version, both bound to the same
+queue group so only one replica handles each message when scaled horizontally.
+
+| Subject pattern | Version | Queue group | Auth |
+| --- | --- | --- | --- |
+| `lfx.index.>` | V2 | `lfx.indexer.queue` | JWT (`authorization` header key) |
+| `lfx.v1.index.>` | V1 (legacy) | `lfx.indexer.queue` | `x-username` / `x-email` headers |
+
+Subject prefix selects the message version. V2 messages use past-tense actions
+(`created`, `updated`, `deleted`); V1 messages use present-tense actions. Both
+subjects and the queue group are overridable via `NATS_INDEXING_SUBJECT`,
+`NATS_V1_INDEXING_SUBJECT`, and `NATS_QUEUE`.
+
+## Reply and outbound events
+
+- Reply: `"OK"` on success, `"ERROR: <details>"` on failure. Replies are required
+  even for fire-and-forget publishers so they can detect handler failure.
+- After every successful OpenSearch write the service publishes a domain event
+  on `lfx.{object_type}.{action}` (e.g. `lfx.project.created`). Publish errors
+  are non-blocking. See `internal/domain/contracts/events.go` for the
+  `IndexingEvent` payload.
+
+For the index envelope (`IndexerMessageEnvelope`) and `IndexingConfig` fields,
+see `lfx-v2-indexer-service/docs/indexer-contract.md`. Both
+structs are defined in `lfx-v2-indexer-service/pkg/types/indexing_config.go`
+(public client surface) and imported by `internal/domain/contracts/transaction.go`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Central LFX skills:**
+> - Start with `/lfx-skills:lfx` for cross-repo tasks, "where does X live" questions, owner/peer repo routing, or missing checkouts.
+> - Use `/lfx-skills:lfx-platform-architecture` after routing when you need platform composition, V2 service classes, write/read/access-check/indexing flows, NATS/KV ownership, or handoff points across FGA, indexer, query, Heimdall, OpenFGA, Helm, or ArgoCD.
+> - The repo-local `indexer-service-dev` skill auto-attaches on Go paths (`cmd/`, `internal/`, `pkg/`, `**/*.go`, `Makefile`, `go.mod`, `go.sum`). It owns the layer boundaries, logging wrapper, NATS subscriber pattern, OpenSearch storage pattern, mocks layout, layer-specific test targets, errors, formatting, lint, and license headers for this repo.
+> - This repo OWNS the indexer event contract. Other V2 services route here to publish index events. The authoritative contract lives in `docs/indexer-contract.md`; the publisher workflow is the local `.claude/skills/indexer-publishing/` skill; contract-sensitive paths are covered by the local `.claude/rules/indexer-contract.md` rule.
+> - Repo-owned docs under `docs/` are canonical for the generic indexer contract and caller examples.
+> - If the plugin is missing, install with `/plugin marketplace add linuxfoundation/lfx-skills` then `/plugin install lfx-skills@lfx-skills`.
+
 ## Essential Commands
 
 ### Development Workflow
@@ -46,7 +54,35 @@ LOG_LEVEL=debug make run
 
 ## Architecture Overview
 
-This is a **Clean Architecture** implementation processing NATS messages into OpenSearch documents. The service handles both modern V2 messages (`lfx.index.*`) and legacy V1 messages (`lfx.v1.index.*`) with queue group load balancing.
+This is a **Clean Architecture** implementation processing NATS messages into OpenSearch documents. The service handles both modern V2 messages (`lfx.index.>`) and legacy V1 messages (`lfx.v1.index.>`) with queue group load balancing.
+
+## Agent Guidance
+
+Repo-owned guidance is split between contract docs and the local skills:
+
+- `docs/indexer-contract.md`: authoritative event contract (envelope, `IndexingConfig`, OpenSearch document fields, schema evolution policy). Other V2 services link here rather than copy.
+- `docs/client-guide.md`: publisher-facing usage walkthrough (for publishers in other services).
+- `.claude/skills/indexer-service-dev/`: repo-local Go conventions (auto-attaches on Go paths).
+- `.claude/skills/indexer-publishing/`: workflow for any change on the indexer write path (both indexer-internal and publishers in other repos).
+- `.claude/rules/indexer-contract.md`: enforced policy on contract-sensitive paths (action constants, additive envelope changes, no new top-level OpenSearch fields without coordination).
+
+Read the contract doc before changing index message handling or advising resource services on indexer publishing.
+
+## Consumed Cross-Repo Contracts
+
+This repo depends on contracts owned elsewhere. Do not copy or infer them from
+local examples. Read the owner file before changing access coordination, query
+coordination, or publisher guidance.
+
+- Generic FGA envelope and access-check contract:
+  `lfx-v2-fga-sync/docs/fga-sync-contract.md`
+- Query-service read behavior over indexed documents:
+  `lfx-v2-query-service/docs/query-service-contract.md`
+- Per-resource indexer emission contracts:
+  `<resource-service>/docs/indexer-contract.md`
+
+Use `/lfx-skills:lfx` if an owner repo is missing locally, the path has moved,
+or the task needs additional peer repos.
 
 ### Layer Boundaries (Dependency Rule: Inner layers cannot depend on outer layers)
 
@@ -78,45 +114,21 @@ NATS → MessagingRepository → IndexingMessageHandler → MessageProcessor →
 
 ### Domain Events (Outbound)
 
-After every successful OpenSearch write, the service publishes a NATS event. The subject is dynamic based on the object type and action — every object type the indexer handles (project, committee, meeting, etc.) automatically gets its own set of event subjects.
-
-**Subject format**: `lfx.{object_type}.{action}`
-
-Examples for `project` (same pattern applies to all object types):
-
-- `lfx.project.created`
-- `lfx.project.updated`
-- `lfx.project.deleted`
-
-Useful wildcard subscriptions:
-
-- `lfx.project.*` — all actions for a specific type
-- `lfx.*.created` — created events across all types
-
-**Payload** (`internal/domain/contracts/events.go` — `IndexingEvent`):
-
-```json
-{
-  "document_id": "project:abc-123",
-  "object_id":   "abc-123",
-  "object_type": "project",
-  "action":      "created",
-  "timestamp":   "2026-03-05T19:57:25.679Z",
-  "body": { ... }
-}
-```
-
-`body` is the full `TransactionBody` written to OpenSearch. Publish failures are **non-blocking** — the OpenSearch write is unaffected and the error is logged.
+After every successful OpenSearch write the service publishes a NATS event on
+`lfx.{object_type}.{action}`. Envelope shape, `IndexingEvent` payload, wildcard
+subscriptions, and failure semantics are documented in the authoritative
+`docs/indexer-contract.md`. Cross-service topology lives in the
+central `/lfx-skills:lfx-platform-architecture` skill.
 
 ### Critical Patterns
 
-**Message Routing**: Subject prefix determines version (`lfx.index.*` = V2, `lfx.v1.index.*` = V1)
+**Message Routing**: Subject prefix determines version (`lfx.index.` = V2, `lfx.v1.index.` = V1)
 
 **Authentication**:
 
-- V2: JWT tokens via `Authorization` header (validated against Heimdall)
-- V1: Simple `X-Username`/`X-Email` headers
-- Delegation: `X-On-Behalf-Of` support
+- V2: JWT tokens via the lower-case `authorization` header key in the NATS JSON envelope (validated against Heimdall)
+- V1: Simple `x-username`/`x-email` headers
+- Delegation: `x-on-behalf-of` support
 
 **Configuration**: CLI flags > Environment variables > Defaults
 
@@ -142,38 +154,21 @@ JANITOR_ENABLED=true
 
 ## Development Guidelines
 
-### Clean Architecture Rules
-
-- Domain layer cannot import from infrastructure/presentation layers
-- All external dependencies must use repository interfaces
-- Business logic stays in domain services
-- Dependency injection only in `cmd/lfx-indexer/main.go`
+Layer boundaries, NATS handler patterns, OpenSearch storage patterns, logging, errors, tests, formatter, lint, and license headers are all owned by `.claude/skills/indexer-service-dev/SKILL.md` (auto-attaches on Go paths).
 
 ### Adding New Object Types
 
-No indexer changes are needed for new object types. The indexer is data-agnostic — publishers send messages with any non-empty `object_type` and a valid `indexing_config` block; the indexer stores and indexes the document without resource-specific logic.
+No indexer changes are needed for new object types. The indexer is data-agnostic: publishers send messages with any non-empty `object_type` and a valid `indexing_config` block; the indexer stores and indexes the document without resource-specific logic. Domain events (`lfx.{object_type}.created/updated/deleted`) are emitted automatically.
 
-Domain events (`lfx.{object_type}.created/updated/deleted`) are emitted automatically for all object types — no additional work required.
-
-### Message Processing Requirements
-
-- Always reply to NATS messages with "OK" or "ERROR: details"
-- Log comprehensive context for debugging (action, object_type, message_id)
-- Handle both V2 (past-tense actions) and V1 (present-tense actions) formats
-- Support base64-encoded data fields
-
-### Testing Strategy
-
-- Use layer-specific make targets for focused testing
-- Mock external dependencies using interfaces in `internal/mocks/`
-- Test both V2 and V1 message formats where applicable
-- Include race detection in all test runs
+Adding a new object type lives on the publisher side. See the `indexer-publishing` skill and `docs/indexer-contract.md`.
 
 ## Key Files for Understanding the System
 
+- `README.md`: Full project-structure tree, mermaid sequence and data-flow diagrams, CLI flag reference, and troubleshooting guide. Read first when orienting in the repo.
 - `internal/domain/services/indexer_service.go`: Core business logic
 - `internal/application/message_processor.go`: Message workflow orchestration
-- `internal/domain/contracts/transaction.go`: Core business entities
-- `internal/domain/contracts/events.go`: `IndexingEvent` — the outbound domain event payload
+- `internal/domain/contracts/transaction.go`: Core business entities (`LFXTransaction`, `TransactionBody`)
+- `internal/domain/contracts/events.go`: `IndexingEvent`, the outbound domain event payload
+- `pkg/types/indexing_config.go`: Public client surface (`IndexerMessageEnvelope`, `IndexingConfig`)
 - `internal/infrastructure/config/app_config.go`: Configuration management
 - `cmd/lfx-indexer/main.go`: Dependency injection and service startup

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ sequenceDiagram
     IS->>IS: EnrichTransaction()<br/>ValidateObjectType()<br/>GenerateTransactionBody()
 
     %% Document Indexing
-    IS->>SR: Index(ctx, index, docID, body)
+    IS->>SR: Index(ctx, index, object_ref, body)
     SR->>OS: POST /resources/_doc/{object_ref}
 
     alt Successful Index

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ sequenceDiagram
 
     %% Document Indexing
     IS->>SR: Index(ctx, index, object_ref, body)
-    SR->>OS: POST /resources/_doc/{object_ref}
+    SR->>OS: PUT /resources/_doc/{object_ref}
 
     alt Successful Index
         OS-->>SR: 201 Created
@@ -297,8 +297,8 @@ sequenceDiagram
         UH->>UH: reply([]byte("OK"))
         Note over UH: Log success metrics
     else Error
-        UH->>UH: reply([]byte("ERROR: details"))
-        Note over UH: Log error with context
+        UH->>UH: reply([]byte("ERROR: ..."))
+        Note over UH: Generic NACK reply<br/>Log error details with context
     end
 
     UH-->>MR: Acknowledge message

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 A high-performance, indexer service for the LFX V2 platform that processes resource transactions into OpenSearch with comprehensive NATS message processing and queue group load balancing.
 
+> Agents working in this repo should start with [`CLAUDE.md`](CLAUDE.md).
+> The authoritative generic indexer event contract lives in
+> [`docs/indexer-contract.md`](docs/indexer-contract.md). Caller examples live
+> in [`docs/client-guide.md`](docs/client-guide.md).
+
 ## 📋 Overview
 
 The LFX V2 Indexer Service is responsible for:
 
 - **Message Processing**: NATS stream processing with queue group load balancing across multiple instances
 - **Transaction Enrichment**: JWT authentication, data validation, and principal parsing with delegation support
-- **Search Indexing**: OpenSearch document indexing with optimistic concurrency control  
+- **Search Indexing**: OpenSearch document writes under the `object_ref` document ID
 - **Data Consistency**: Event-driven janitor service for conflict resolution
 - **Dual Format Support**: Both LFX v2 (past-tense actions) and legacy v1 (present-tense actions) message formats
 - **Health Monitoring**: Kubernetes-ready health check endpoints
@@ -99,7 +104,6 @@ curl http://localhost:8080/health   # General health
 ├─────────────────────────────────────────────────────────────────┤
 │  Presentation Layer (NATS Protocol + Health Checks)            │
 │  ├─ IndexingMessageHandler - Unified V2/V1 message processing │
-│  ├─ BaseMessageHandler - Shared NATS response logic          │
 │  └─ HealthHandler - Kubernetes health probes                  │
 ├─────────────────────────────────────────────────────────────────┤
 │  Application Layer (Orchestration)                             │
@@ -136,8 +140,8 @@ graph TB
 
     %% NATS Infrastructure
     NATS_SERVER["NATS Server<br/>nats://nats:4222"]
-    V2_SUBJECT["V2 Subject: lfx.index.*<br/>(lfx.index.project, lfx.index.organization)"]
-    V1_SUBJECT["V1 Subject: lfx.v1.index.*<br/>(lfx.v1.index.project)"]
+    V2_SUBJECT["V2 Subject: lfx.index.><br/>(lfx.index.project, lfx.index.organization)"]
+    V1_SUBJECT["V1 Subject: lfx.v1.index.><br/>(lfx.v1.index.project)"]
     QUEUE_GROUP["Queue Group: lfx.indexer.queue<br/>(Load Balancing)"]
 
     %% Service Instances
@@ -269,7 +273,7 @@ sequenceDiagram
 
     %% Document Indexing
     IS->>SR: Index(ctx, index, docID, body)
-    SR->>OS: POST /resources/_doc/{docID}<br/>with optimistic concurrency
+    SR->>OS: POST /resources/_doc/{object_ref}
 
     alt Successful Index
         OS-->>SR: 201 Created
@@ -340,8 +344,8 @@ JANITOR_ENABLED=true                         # Enable cleanup service (default: 
 
 | Subject Pattern | Purpose | Example | Load Balancing |
 |----------------|---------|---------|----------------|
-| `lfx.index.*` | V2 resource indexing | `lfx.index.project`, `lfx.index.organization` | Queue group distribution |
-| `lfx.v1.index.*` | V1 legacy support | `lfx.v1.index.project` | Queue group distribution |
+| `lfx.index.>` | V2 resource indexing | `lfx.index.project`, `lfx.index.organization` | Queue group distribution |
+| `lfx.v1.index.>` | V1 legacy support | `lfx.v1.index.project` | Queue group distribution |
 
 **Queue Group**: `lfx.indexer.queue`
 
@@ -409,8 +413,8 @@ JANITOR_ENABLED=true                         # Enable cleanup service (default: 
 │       ├── logger.go             # Logger implementation
 │       ├── logger_test.go        # Logger tests
 │       └── testing.go            # Test logging utilities
-├── deployment/                   # Deployment configurations
-│   └── deployment.yaml          # Kubernetes deployment
+├── charts/                       # Helm chart for Kubernetes deployment
+│   └── lfx-v2-indexer-service/   # Chart templates and values
 ├── Dockerfile                    # Container definition
 ├── Makefile                      # Build automation
 ├── go.mod                        # Go module definition
@@ -504,33 +508,53 @@ make coverage                      # Generate coverage report
 ### Testing Message Processing
 
 ```bash
-# Test V2 message format
-nats pub lfx.index.project '{
+# Test V2 message format and wait for OK/ERROR reply
+nats request lfx.index.project '{
   "action": "created",
-  "headers": {"Authorization": "Bearer token"},
+  "headers": {"authorization": "Bearer <valid JWT>"},
   "data": {
     "id": "test-project-123",
     "uid": "test-project-123",
     "name": "Test Project",
     "slug": "test-project",
     "public": true
+  },
+  "indexing_config": {
+    "object_id": "test-project-123",
+    "public": true,
+    "access_check_object": "project:test-project-123",
+    "access_check_relation": "viewer",
+    "history_check_object": "project:test-project-123",
+    "history_check_relation": "historian",
+    "sort_name": "test project",
+    "name_and_aliases": ["Test Project"],
+    "tags": ["slug:test-project"]
   }
 }' --server nats://your-nats-server:4222
 
 # Test V1 message format
-nats pub lfx.v1.index.project '{
+nats request lfx.v1.index.project '{
   "action": "create",
   "data": {
     "id": "test-project-456",
     "name": "Legacy Project"
+  },
+  "indexing_config": {
+    "object_id": "test-project-456",
+    "access_check_object": "project:test-project-456",
+    "access_check_relation": "viewer",
+    "history_check_object": "project:test-project-456",
+    "history_check_relation": "historian",
+    "sort_name": "legacy project",
+    "name_and_aliases": ["Legacy Project"]
   },
   "v1_data": {
     "legacy_field": "legacy_value"
   }
 }' --server nats://your-nats-server:4222
 
-# Monitor processing
-nats sub "lfx.index.>" --server nats://your-nats-server:4222
+# Monitor emitted post-index events for this resource type
+nats sub "lfx.project.*" --server nats://your-nats-server:4222
 ```
 
 ## 🚨 Troubleshooting
@@ -601,7 +625,7 @@ LOG_LEVEL=debug make run
 
 - **Heimdall Integration**: All messages validated against JWT service
 - **Multiple Audiences**: Configurable audience validation
-- **Principal Parsing**: Authorization header and X-On-Behalf-Of delegation support
+- **Principal Parsing**: `authorization` header and `x-on-behalf-of` delegation support
 - **Machine User Detection**: `clients@` prefix identification
 
 **Input Validation:**

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -1,6 +1,9 @@
 # Client Guide: Indexing Resources in LFX
 
 This guide explains how to send messages to the LFX Indexer Service to index your resources in OpenSearch.
+It is a caller-facing walkthrough. The authoritative generic envelope,
+`IndexingConfig`, OpenSearch document fields, event semantics, and schema
+evolution policy live in [`docs/indexer-contract.md`](indexer-contract.md).
 
 ## Table of Contents
 
@@ -25,7 +28,7 @@ type IndexerMessageEnvelope struct {
     Action         string                 // "created", "updated", or "deleted"
     Headers        map[string]string      // Authentication headers
     Data           any                    // Resource data (map or string for deletes)
-    Tags           []string               // Optional: fields to index as tags
+    Tags           []string               // Optional exact tags merged with indexing_config.tags
     IndexingConfig *IndexingConfig        // Required for create/update; omit for delete
 }
 ```
@@ -61,7 +64,6 @@ Create and update messages must include the `indexing_config` field to provide c
     "slug": "my-project",
     "description": "A sample project"
   },
-  "tags": ["uid", "slug"],
   "indexing_config": {
     "object_id": "proj-123",
     "public": true,
@@ -72,7 +74,7 @@ Create and update messages must include the `indexing_config` field to provide c
     "sort_name": "my project",
     "name_and_aliases": ["My Project", "my-project"],
     "parent_refs": ["org:org-456"],
-    "tags": ["featured", "active"],
+    "tags": ["uid:proj-123", "slug:my-project", "featured", "active"],
     "fulltext": "My Project - A sample project for demonstration"
   }
 }
@@ -127,7 +129,6 @@ Templates use double curly braces: `{{ field_name }}`
       }
     }
   },
-  "tags": ["uid", "slug"],
   "indexing_config": {
     "object_id": "{{ uid }}",
     "public": true,
@@ -138,6 +139,7 @@ Templates use double curly braces: `{{ field_name }}`
     "sort_name": "{{ name }}",
     "name_and_aliases": ["{{ name }}", "{{ slug }}"],
     "parent_refs": ["org:{{ parent_id }}", "org:{{ metadata.organization.id }}"],
+    "tags": ["uid:{{ uid }}", "slug:{{ slug }}"],
     "fulltext": "{{ name }} - Project in organization {{ metadata.organization.id }}"
   }
 }
@@ -162,7 +164,6 @@ Templates use double curly braces: `{{ field_name }}`
       }
     }
   },
-  "tags": ["uid", "slug"],
   "indexing_config": {
     "object_id": "proj-123",
     "public": true,
@@ -173,6 +174,7 @@ Templates use double curly braces: `{{ field_name }}`
     "sort_name": "My Project",
     "name_and_aliases": ["My Project", "my-project"],
     "parent_refs": ["org:org-456", "org:org-789"],
+    "tags": ["uid:proj-123", "slug:my-project"],
     "fulltext": "My Project - Project in organization org-789"
   }
 }
@@ -184,7 +186,10 @@ Templates use double curly braces: `{{ field_name }}`
 2. **Nested Access**: Use dot notation (e.g., `{{ parent.id }}`) for nested objects
 3. **Type Preservation**: Simple templates (`"{{ field }}"`) preserve the original type
 4. **String Conversion**: Embedded templates convert values to strings
-5. **Error Handling**: Missing fields return an error during processing
+5. **Error Handling**: Missing fields in required whole-value templates become empty
+   and then fail required-field validation; missing fields in optional or embedded
+   templates are skipped with a warning and blank substitution. Traversing through
+   a non-object still fails processing.
 6. **Escaping**: Use `\{{ }}` to include literal curly braces in values
 7. **Whitespace**: Whitespace inside templates is trimmed (e.g., `{{  uid  }}` → `uid`)
 
@@ -226,7 +231,7 @@ Templates use double curly braces: `{{ field_name }}`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `tags` | array | No | Field names from `data` to index as searchable tags |
+| `tags` | array | No | Optional exact tags merged with `indexing_config.tags`. Prefer `indexing_config.tags` for new publishers. |
 | `indexing_config` | object | Yes (create/update) | Indexing metadata controlling access control, search, and sort behavior. Not required for delete. |
 
 ### IndexingConfig Fields
@@ -249,7 +254,7 @@ Templates use double curly braces: `{{ field_name }}`
 | `sort_name` | string | Normalized name for sorting | `"my project"` |
 | `name_and_aliases` | array | Names and aliases for search | `["My Project", "MP"]` |
 | `parent_refs` | array | References to parent resources | `["org:org-456"]` |
-| `tags` | array | Additional static tags for the document | `["featured", "active"]` |
+| `tags` | array | Exact-match tags for filtering | `["uid:proj-123", "status:active"]` |
 | `fulltext` | string | Full-text search content | `"searchable content"` |
 | `contacts` | array | Contact information for the resource (see Contact structure below) | See example below |
 
@@ -349,7 +354,6 @@ These fields are **always set by the server** and should **not** be included in 
     "slug": "my-project",
     "parent_id": "org-456"
   },
-  "tags": ["uid", "slug"],
   "indexing_config": {
     "object_id": "proj-123",
     "public": true,
@@ -360,7 +364,7 @@ These fields are **always set by the server** and should **not** be included in 
     "sort_name": "my project",
     "name_and_aliases": ["My Project", "my-project"],
     "parent_refs": ["org:org-456"],
-    "tags": ["featured"],
+    "tags": ["uid:proj-123", "slug:my-project", "featured"],
     "fulltext": "My Project - A sample project"
   }
 }
@@ -445,7 +449,7 @@ Note: For delete operations, `indexing_config` is not needed. The server only re
 4. **tags**: Add categorical tags
    - Keep tags concise
    - Use consistent naming conventions
-   - Example: `["featured", "active", "verified"]`
+   - Example: `["uid:proj-123", "status:active", "featured"]`
 
 5. **fulltext**: Construct comprehensive search text
    - Include name, description, and other searchable content
@@ -499,8 +503,8 @@ For Go services, use the public types package:
 
 ```go
 import (
-    "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
     "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+    "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/types"
 )
 
 // Create message with indexing config
@@ -508,7 +512,7 @@ publicFlag := true
 envelope := &types.IndexerMessageEnvelope{
     Action: constants.ActionCreated,
     Headers: map[string]string{
-        "authorization": "Bearer " + token,
+        constants.AuthorizationHeader: "Bearer " + token,
     },
     Data: map[string]any{
         "id":   "proj-123",
@@ -523,7 +527,7 @@ envelope := &types.IndexerMessageEnvelope{
         HistoryCheckRelation: "historian",
         SortName:             "my project",
         NameAndAliases:       []string{"My Project"},
-        Tags:                 []string{"featured"},
+        Tags:                 []string{"uid:proj-123", "featured"},
     },
 }
 
@@ -536,9 +540,12 @@ nc.Publish("lfx.index.project", data)
 
 ### Issue: Document missing server-side fields
 
-**Problem**: `latest`, `created_at`, or principal fields are missing in OpenSearch.
+**Problem**: `latest`, timestamp, or principal fields are missing in OpenSearch.
 
-**Solution**: This was a bug fixed in recent versions. Ensure you're using the latest indexer service version. These fields are always set by the server automatically.
+**Solution**: Confirm the write went through indexer-service and returned `OK`.
+Create/update documents get `created_at` or `updated_at`; delete documents get
+`deleted_at`. Principal fields require a valid lower-case `authorization` header
+on V2 messages or `x-username` / `x-email` on V1 messages.
 
 ### Issue: "indexing_config is required" error
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -1,0 +1,276 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Indexer Event Contract (Authoritative)
+
+This is the **owner document** for the indexer event envelope, the OpenSearch document
+shape, and the rules the indexer enforces on incoming messages. Other services link
+here rather than copy.
+
+The indexer subscribes to `lfx.index.>` (V2) and `lfx.v1.index.>` (V1) NATS subjects
+on a queue group, writes documents into OpenSearch, and emits domain events on
+`lfx.{object_type}.{action}`. It is fully generic; resource services tell it
+everything it needs via the message payload.
+
+## Subject Conventions
+
+Publish a V2 index message on `lfx.index.{resource_type}`. Use lowercase, underscore-
+separated resource types. The subject suffix becomes `object_type` in the indexed
+document. Do not invent ad-hoc variants for the same logical type:
+
+```text
+lfx.index.committee
+lfx.index.committee_member
+lfx.index.vote
+lfx.index.survey
+lfx.index.project_settings
+```
+
+V1 publishers use `lfx.v1.index.{resource_type}` and present-tense actions
+(`create`/`update`/`delete`); V2 uses past-tense (`created`/`updated`/`deleted`).
+The service subscribes to `lfx.v1.index.>` for legacy traffic. Use the constants
+in `pkg/constants/` rather than string literals.
+
+## Envelope: `IndexerMessageEnvelope`
+
+Defined in the public `pkg/types/indexing_config.go` package (imported by
+`internal/domain/contracts/transaction.go`).
+
+```go
+type IndexerMessageEnvelope struct {
+    Action         constants.MessageAction `json:"action"`           // "created", "updated", "deleted"
+    Headers        map[string]string       `json:"headers"`          // auth headers from request context
+    Data           any                     `json:"data"`             // full resource struct; bare UID string for deletes
+    Tags           []string                `json:"tags,omitempty"`
+    IndexingConfig *IndexingConfig         `json:"indexing_config,omitempty"`
+}
+```
+
+Field rules the indexer enforces:
+
+- `Action` must be one of the action constants. Unknown actions are rejected.
+- `Headers` should carry lower-case JSON keys `authorization` and `x-on-behalf-of`
+  from the request context. They become the audit principal in the OpenSearch document.
+- `Data` is stored as-is in the `data` OpenSearch field (`flat_object`, schema-free).
+- **Deletes**: set `action = "deleted"` and `Data` = the plain UID string. Do not send
+  the full resource on a delete.
+
+Always use action constants. Never hardcode strings:
+
+```go
+constants.ActionCreated  // "created"
+constants.ActionUpdated  // "updated"
+constants.ActionDeleted  // "deleted"
+```
+
+## Required: `IndexingConfig`
+
+`IndexingConfig` is how a publisher tells the indexer how to build a well-structured
+OpenSearch document. **All publishers must include it on every create/update.**
+Deletes do not need it because the delete payload is only the object ID. Create/update
+messages without it are rejected by the indexer (`indexing_config is required`).
+
+```go
+type IndexingConfig struct {
+    // Required: identifies the resource and how to check access
+    ObjectID             string `json:"object_id"`              // resource UUID
+    AccessCheckObject    string `json:"access_check_object"`    // e.g. "vote:abc-123"
+    AccessCheckRelation  string `json:"access_check_relation"`  // e.g. "viewer"
+    HistoryCheckObject   string `json:"history_check_object"`   // e.g. "vote:abc-123"
+    HistoryCheckRelation string `json:"history_check_relation"` // e.g. "auditor"
+
+    // Search and discovery fields
+    Public         *bool         `json:"public,omitempty"`           // true = skip auth check for anonymous
+    SortName       string        `json:"sort_name,omitempty"`        // sortable name
+    NameAndAliases []string      `json:"name_and_aliases,omitempty"` // typeahead / search-as-you-type
+    ParentRefs     []string      `json:"parent_refs,omitempty"`      // e.g. ["project:xyz", "committee:abc"]
+    Tags           []string      `json:"tags,omitempty"`             // exact-match filtering
+    Fulltext       string        `json:"fulltext,omitempty"`         // free-text search blob
+    Contacts       []ContactBody `json:"contacts,omitempty"`
+}
+```
+
+### What the indexer rejects
+
+| Condition | Outcome |
+|---|---|
+| Missing `IndexingConfig` on create/update | Message rejected with error reply |
+| Empty `ObjectID` | Rejected (no primary key) |
+| Empty `AccessCheckObject` or `AccessCheckRelation` | Rejected during `IndexingConfig` parsing |
+| Empty `HistoryCheckObject` or `HistoryCheckRelation` | Rejected during `IndexingConfig` parsing |
+| Unknown `action` value | Rejected with `unknown action` |
+| Missing lower-case `authorization` header on V2 messages | Rejected during header validation |
+| `data` not present on create/update | Rejected |
+| `data` not a string on delete | Rejected |
+| Subject suffix empty (`lfx.index.` with no type) | Rejected (must have a non-empty resource type) |
+| Subject suffix contains `.`, `*`, `>`, whitespace, or equals `index` | Rejected (invalid or reserved object type) |
+
+NATS replies are mandatory: handlers reply `OK` on success or `ERROR: <details>` on
+failure. Publishers should use request/reply to confirm processing during writes that
+require acknowledgement.
+
+### Choosing search fields
+
+| Field | When to populate |
+|---|---|
+| `NameAndAliases` | Primary name/title users search for (typeahead) |
+| `Tags` | Values used for exact filtering (e.g. `project_uid:abc`, `status:active`) |
+| `Fulltext` | Any text content users might search within |
+| `ParentRefs` | Parent resource refs (always include if the resource belongs to a project) |
+| `data` only | Fields that are display-only and never searched |
+
+### Full example (voting-service pattern)
+
+```go
+public := vote.Public
+indexingConfig := &indexerTypes.IndexingConfig{
+    ObjectID:             vote.UID,
+    AccessCheckObject:    fmt.Sprintf("vote:%s", vote.UID),
+    AccessCheckRelation:  "viewer",
+    HistoryCheckObject:   fmt.Sprintf("vote:%s", vote.UID),
+    HistoryCheckRelation: "auditor",
+    SortName:             vote.Name,
+    NameAndAliases:       []string{vote.Name},
+    ParentRefs:           []string{fmt.Sprintf("project:%s", vote.ProjectUID)},
+    Tags:                 vote.Tags(),
+    Fulltext:             fmt.Sprintf("%s %s", vote.Name, vote.Description),
+    Public:               &public,
+}
+
+msg := indexerTypes.IndexerMessageEnvelope{
+    Action:         constants.ActionCreated,
+    Headers:        headersFromContext(ctx),
+    Data:           vote,
+    IndexingConfig: indexingConfig,
+}
+```
+
+## OpenSearch Document Shape (the indexer writes)
+
+The indexer is the only writer of the document. It writes using `object_ref` as the
+OpenSearch document ID. Field naming below is fixed; do not introduce new top-level
+fields without coordination with this service.
+
+| Field | Populated from | Purpose |
+|---|---|---|
+| `object_ref` | `{type}:{id}` | Primary identifier (e.g. `committee:abc-123`) |
+| `object_type` | NATS subject suffix | Filtering queries by resource type |
+| `object_id` | `IndexingConfig.ObjectID` | UUID lookup |
+| `parent_refs` | `IndexingConfig.ParentRefs` | Hierarchy navigation |
+| `sort_name` | `IndexingConfig.SortName` | Sorting results |
+| `name_and_aliases` | `IndexingConfig.NameAndAliases` | Typeahead search field |
+| `tags` | top-level envelope `Tags` plus `IndexingConfig.Tags` | Exact-match filtering |
+| `fulltext` | `IndexingConfig.Fulltext` | Free-text search blob |
+| `contacts` | `IndexingConfig.Contacts` | Contact search/display metadata |
+| `public` | `IndexingConfig.Public` | Anonymous queries filter on this; skips FGA check |
+| `access_check_object` | `IndexingConfig.AccessCheckObject` | Compatibility field; prefer `access_check_query` |
+| `access_check_relation` | `IndexingConfig.AccessCheckRelation` | Compatibility field; prefer `access_check_query` |
+| `history_check_object` | `IndexingConfig.HistoryCheckObject` | Compatibility field; prefer `history_check_query` |
+| `history_check_relation` | `IndexingConfig.HistoryCheckRelation` | Compatibility field; prefer `history_check_query` |
+| `access_check_query` | `{AccessCheckObject}#{AccessCheckRelation}` | Used by query-service to build FGA check |
+| `history_check_query` | `{HistoryCheckObject}#{HistoryCheckRelation}` | Used by query-service for audit views |
+| `latest` | Set by indexer | `true` for current version only |
+| `created_at`, `updated_at`, `deleted_at` | server timestamp by action | Audit and sorting timestamps |
+| `created_by`, `updated_by`, `deleted_by` | parsed principals | Human-readable principal refs |
+| `created_by_principals`, `updated_by_principals`, `deleted_by_principals` | parsed principals | Principal IDs for filtering/audit |
+| `created_by_emails`, `updated_by_emails`, `deleted_by_emails` | parsed principals | Principal email addresses |
+| `data` | `IndexerMessageEnvelope.Data` on create/update | Full resource data (schema-free `flat_object`) |
+| `v1_data` | V1 payload only | Legacy Platform DB data retained for V1 imports |
+
+### Field-naming rules
+
+- All top-level field names are `snake_case`. No camelCase, no dashes, no spaces.
+- Reserve `object_*`, `access_check_*`, `history_check_*`, `parent_refs`, `latest`,
+  `sort_name`, `name_and_aliases`, `public`, `data`, `v1_data`, `tags`, `fulltext`,
+  `contacts`, and the audit fields (`created_*`, `updated_*`, `deleted_*`) for this
+  contract. Resource-specific data lives inside `data`.
+- Anything in `data` is dynamic. OpenSearch maps new keys via `flat_object`, but
+  you cannot rely on per-field analyzers there. Use the search-shaped fields above
+  when you need analysis or aggregation.
+
+### Current-document and janitor behavior
+
+The current write path uses the OpenSearch Index API with `object_ref` as the document ID.
+Each create, update, or delete writes the current document for that object reference and
+sets `latest: true`; deletes write a tombstone-shaped document with `deleted_at` and
+delete principals. The janitor still scans for duplicate `latest: true` hits with the
+same `object_ref` and flips older duplicates to `latest: false` using optimistic update
+parameters. Queries must filter `latest: true` to see current data.
+
+### Domain events emitted after a successful write
+
+```text
+lfx.{object_type}.{action}
+```
+
+Payload (`internal/domain/contracts/events.go`, `IndexingEvent`):
+
+```json
+{
+  "document_id": "project:abc-123",
+  "object_id":   "abc-123",
+  "object_type": "project",
+  "action":      "created",
+  "timestamp":   "2026-03-05T19:57:25.679Z",
+  "body": { ... }
+}
+```
+
+`body` is the full `TransactionBody` written to OpenSearch. Publish failures here are
+**non-blocking**: the OpenSearch write is unaffected; the error is logged.
+
+## Schema Evolution Policy
+
+- **Adding fields inside `data`**: free. `flat_object` accepts new keys without a
+  mapping change. If the field needs to be searchable/filterable, route it through
+  `IndexingConfig` (Tags / NameAndAliases / Fulltext) instead of relying on `data`.
+- **Adding top-level fields to the OpenSearch document**: requires an indexer-service
+  change. Do not invent new top-level fields in a publisher.
+- **Renaming or removing top-level fields**: breaking. Coordinate with the indexer
+  team and the query-service team; existing documents must be re-indexed.
+- **Changing `IndexingConfig` shape**: breaking for all publishers. Coordinate.
+- **Adding a new resource type**: no indexer change needed. Publish on
+  `lfx.index.<new_type>` with a valid envelope and `IndexingConfig`. Domain events
+  `lfx.<new_type>.created/updated/deleted` are emitted automatically.
+
+## Publisher Validation Checklist
+
+Before merging a change to publisher code in a resource service, verify:
+
+1. Every create/update path sends a non-nil `IndexingConfig` with `ObjectID`,
+   `AccessCheckObject`, `AccessCheckRelation`, `HistoryCheckObject`, and
+   `HistoryCheckRelation` populated.
+2. Deletes use `action = "deleted"` and `Data` = the UID string (not the resource).
+3. The subject matches the resource type that other services already use; check
+   `pkg/constants/` for the canonical constant.
+4. The publisher waits for `OK` on the reply when the write must be confirmed
+   (or accepts fire-and-forget for non-critical writes; document which).
+5. Headers carry lower-case `authorization` and `x-on-behalf-of` keys so audit principals are
+   recorded on the indexed document.
+
+## Adding a New Field to an Existing Resource
+
+Adding a new field to the `data` payload requires no OpenSearch schema changes. `data`
+is a `flat_object` and OpenSearch handles new keys dynamically.
+
+If the new field should also be **searchable**, update the `IndexingConfig` construction
+in the resource service's NATS publisher to include it in the appropriate search field
+(`NameAndAliases`, `Tags`, or `Fulltext`).
+
+## Per-Service Contract Docs
+
+Services that follow the indexer contract pattern keep a `docs/indexer-contract.md` at
+the repo root. This is the authoritative reference for that service's data schemas,
+tags, access control config, parent references, and fulltext fields, derived directly
+from the source code.
+
+**Read this before writing or modifying indexing code for an existing service.** It
+tells you what is already indexed and how, so you don't duplicate tags, miss required
+fields, or break existing query patterns.
+
+**Update it in the same PR as any indexing change.** The doc must stay in sync with
+the code.
+
+Use an existing resource service as a shape-only example when adding a contract
+to a new service. Do not copy service-specific schemas, tags, access config, or
+parent references; the target service owns its own contract.

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -105,10 +105,12 @@ type IndexingConfig struct {
 | Subject suffix empty (`lfx.index.` with no type) | Rejected (must have a non-empty resource type) |
 | Subject suffix contains `.`, `*`, `>`, whitespace, or equals `index` | Rejected (invalid or reserved object type) |
 
-When a reply subject is provided (request/reply), handlers reply `OK` on success or
-`ERROR: <details>` on failure. Plain `Publish` without a reply inbox receives no reply.
-Publishers should use request/reply to confirm processing during writes that require
-acknowledgement.
+When a reply subject is provided (request/reply), handlers reply `OK` on success or an
+`ERROR: ...` string on failure. The error reply is a generic NACK (currently
+`ERROR: error processing indexing message`), not a detailed error description; callers
+must treat replies strictly as ACK/NACK signals and use the indexer logs for failure
+diagnostics. Plain `Publish` without a reply inbox receives no reply. Publishers should
+use request/reply to confirm processing during writes that require acknowledgement.
 
 ### Choosing search fields
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -105,9 +105,10 @@ type IndexingConfig struct {
 | Subject suffix empty (`lfx.index.` with no type) | Rejected (must have a non-empty resource type) |
 | Subject suffix contains `.`, `*`, `>`, whitespace, or equals `index` | Rejected (invalid or reserved object type) |
 
-NATS replies are mandatory: handlers reply `OK` on success or `ERROR: <details>` on
-failure. Publishers should use request/reply to confirm processing during writes that
-require acknowledgement.
+When a reply subject is provided (request/reply), handlers reply `OK` on success or
+`ERROR: <details>` on failure. Plain `Publish` without a reply inbox receives no reply.
+Publishers should use request/reply to confirm processing during writes that require
+acknowledgement.
 
 ### Choosing search fields
 

--- a/internal/application/message_processor.go
+++ b/internal/application/message_processor.go
@@ -31,8 +31,10 @@ type MessageProcessor struct {
 	logger            *slog.Logger
 
 	// Configuration
-	index string
-	queue string
+	index             string
+	queue             string
+	indexingSubject   string
+	v1IndexingSubject string
 }
 
 // NewMessageProcessor creates a new message processor
@@ -49,6 +51,24 @@ func NewMessageProcessor(
 		logger:            logging.WithComponent(logger, "message_processor"),
 		index:             constants.DefaultIndex,
 		queue:             constants.DefaultQueue,
+		indexingSubject:   constants.AllSubjects,
+		v1IndexingSubject: constants.AllV1Subjects,
+	}
+}
+
+// Configure applies runtime workflow settings loaded by the container.
+func (mp *MessageProcessor) Configure(index, queue, indexingSubject, v1IndexingSubject string) {
+	if index != "" {
+		mp.index = index
+	}
+	if queue != "" {
+		mp.queue = queue
+	}
+	if indexingSubject != "" {
+		mp.indexingSubject = indexingSubject
+	}
+	if v1IndexingSubject != "" {
+		mp.v1IndexingSubject = v1IndexingSubject
 	}
 }
 
@@ -246,34 +266,34 @@ func (mp *MessageProcessor) StartSubscriptions(ctx context.Context) error {
 		"index", mp.index)
 
 	// Subscribe to V2 indexing messages
-	if err := mp.subscribeTo(ctx, constants.AllSubjects, "V2 indexing messages"); err != nil {
+	if err := mp.subscribeTo(ctx, mp.indexingSubject, "V2 indexing messages"); err != nil {
 		logger.Error("Failed to subscribe to V2 messages",
-			"subjects", constants.AllSubjects,
+			"subjects", mp.indexingSubject,
 			"queue", mp.queue,
 			"error", err.Error())
 		return fmt.Errorf("failed to subscribe to V2 messages: %w", err)
 	}
 
 	logger.Info("V2 subscription successful",
-		"subjects", constants.AllSubjects,
+		"subjects", mp.indexingSubject,
 		"queue", mp.queue)
 
 	// Subscribe to V1 indexing messages
-	if err := mp.subscribeTo(ctx, constants.AllV1Subjects, "V1 indexing messages"); err != nil {
+	if err := mp.subscribeTo(ctx, mp.v1IndexingSubject, "V1 indexing messages"); err != nil {
 		logger.Error("Failed to subscribe to V1 messages",
-			"subjects", constants.AllV1Subjects,
+			"subjects", mp.v1IndexingSubject,
 			"queue", mp.queue,
 			"error", err.Error())
 		return fmt.Errorf("failed to subscribe to V1 messages: %w", err)
 	}
 
 	logger.Info("V1 subscription successful",
-		"subjects", constants.AllV1Subjects,
+		"subjects", mp.v1IndexingSubject,
 		"queue", mp.queue)
 
 	logger.Info("All NATS subscriptions started successfully",
-		"v2_subjects", constants.AllSubjects,
-		"v1_subjects", constants.AllV1Subjects,
+		"v2_subjects", mp.indexingSubject,
+		"v1_subjects", mp.v1IndexingSubject,
 		"queue", mp.queue)
 
 	return nil

--- a/internal/application/message_processor_test.go
+++ b/internal/application/message_processor_test.go
@@ -182,6 +182,19 @@ func TestNewMessageProcessor(t *testing.T) {
 	assert.NotNil(t, mp.logger)
 	assert.Equal(t, constants.DefaultIndex, mp.index)
 	assert.Equal(t, constants.DefaultQueue, mp.queue)
+	assert.Equal(t, constants.AllSubjects, mp.indexingSubject)
+	assert.Equal(t, constants.AllV1Subjects, mp.v1IndexingSubject)
+}
+
+func TestMessageProcessor_Configure(t *testing.T) {
+	mp, _, _ := setupTestMessageProcessor()
+
+	mp.Configure("custom-index", "custom-queue", "custom.index.>", "custom.v1.index.>")
+
+	assert.Equal(t, "custom-index", mp.index)
+	assert.Equal(t, "custom-queue", mp.queue)
+	assert.Equal(t, "custom.index.>", mp.indexingSubject)
+	assert.Equal(t, "custom.v1.index.>", mp.v1IndexingSubject)
 }
 
 // Test ProcessIndexingMessage success case
@@ -221,6 +234,42 @@ func TestMessageProcessor_ProcessIndexingMessage_Success(t *testing.T) {
 	err = mp.ProcessIndexingMessage(ctx, data, subject)
 
 	// Assertions
+	assert.NoError(t, err)
+	mockStorageRepo.AssertExpectations(t)
+	mockMessagingRepo.AssertExpectations(t)
+}
+
+func TestMessageProcessor_ProcessIndexingMessage_UsesConfiguredIndex(t *testing.T) {
+	mp, mockMessagingRepo, mockStorageRepo := setupTestMessageProcessor()
+	mp.Configure("configured-index", "", "", "")
+	ctx := context.Background()
+
+	testData := map[string]any{
+		"action": "created",
+		"data": map[string]any{
+			"id":   "test-123",
+			"name": "Test Project",
+		},
+		"headers": map[string]string{
+			"authorization": "Bearer test-token",
+		},
+		"indexing_config": map[string]any{
+			"object_id":              "test-123",
+			"access_check_object":    "project:test-123",
+			"access_check_relation":  "viewer",
+			"history_check_object":   "project:test-123",
+			"history_check_relation": "viewer",
+		},
+	}
+	data, err := json.Marshal(testData)
+	require.NoError(t, err)
+
+	mockStorageRepo.On("Index", mock.Anything, "configured-index", "project:test-123", mock.Anything).Return(nil)
+	mockMessagingRepo.On("ParsePrincipals", mock.Anything, mock.Anything).Return([]contracts.Principal{}, nil)
+	mockMessagingRepo.On("Publish", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	err = mp.ProcessIndexingMessage(ctx, data, "lfx.index.project")
+
 	assert.NoError(t, err)
 	mockStorageRepo.AssertExpectations(t)
 	mockMessagingRepo.AssertExpectations(t)
@@ -395,10 +444,11 @@ func TestMessageProcessor_ProcessV1IndexingMessage_InvalidSubject(t *testing.T) 
 func TestMessageProcessor_StartSubscriptions_Success(t *testing.T) {
 	mp, mockMessagingRepo, _ := setupTestMessageProcessor()
 	ctx := context.Background()
+	mp.Configure("", "custom-queue", "custom.index.>", "custom.v1.index.>")
 
 	// Mock expectations
-	mockMessagingRepo.On("QueueSubscribeWithReply", mock.Anything, constants.AllSubjects, constants.DefaultQueue, mock.Anything).Return(nil)
-	mockMessagingRepo.On("QueueSubscribeWithReply", mock.Anything, constants.AllV1Subjects, constants.DefaultQueue, mock.Anything).Return(nil)
+	mockMessagingRepo.On("QueueSubscribeWithReply", mock.Anything, "custom.index.>", "custom-queue", mock.Anything).Return(nil)
+	mockMessagingRepo.On("QueueSubscribeWithReply", mock.Anything, "custom.v1.index.>", "custom-queue", mock.Anything).Return(nil)
 
 	// Execute
 	err := mp.StartSubscriptions(ctx)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -293,6 +293,12 @@ func (c *Container) initializeApplication() error {
 		c.CleanupRepository,
 		c.Logger,
 	)
+	c.MessageProcessor.Configure(
+		c.Config.OpenSearch.Index,
+		c.Config.NATS.Queue,
+		c.Config.NATS.IndexingSubject,
+		c.Config.NATS.V1IndexingSubject,
+	)
 
 	return nil
 }

--- a/pkg/types/indexing_config.go
+++ b/pkg/types/indexing_config.go
@@ -58,7 +58,7 @@ type ContactBody struct {
 //			"id":   "proj-123",
 //			"name": "My Project",
 //		},
-//		Tags: []string{"uid", "slug"},
+//		Tags: []string{"uid:proj-123", "slug:my-project"},
 //		IndexingConfig: &types.IndexingConfig{
 //			ObjectID:             "proj-123",
 //			AccessCheckObject:    "project:proj-123",
@@ -82,8 +82,8 @@ type IndexerMessageEnvelope struct {
 	// For "deleted" actions, this can be just the resource ID as a string.
 	Data any `json:"data"`
 
-	// Tags (optional) specifies which fields in the data should be indexed as searchable tags.
-	// These are separate from IndexingConfig.Tags which are additional static tags for the document.
+	// Tags (optional) specifies exact tags to merge with IndexingConfig.Tags.
+	// Prefer IndexingConfig.Tags for new publishers so access, search, and filter metadata stay together.
 	Tags []string `json:"tags,omitempty"`
 
 	// IndexingConfig provides indexing metadata required for create/update actions.


### PR DESCRIPTION
## Summary

Part of the LFX developer-AI **fan-out** ([LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)): repo-specific AI guidance moves out of the central `lfx-skills` plugin and into each owning repo, beside the code it describes. This PR lands this repo's share of that work.

> ## 📖 Read these first (they explain this PR)
>
> This is one of ~15 coordinated fan-out PRs. **Before reviewing, please read the three short docs that explain the whole change** — they are the source of truth for the model and for what landed where:
>
> | Doc | What it gives you |
> |---|---|
> | 👉 **[Fan-out architecture](https://docs.google.com/document/d/10eZy8n5xgU7LratcntjkUjGSZmuHpO0xUkskJbJPkfc/edit?usp=sharing)** | The end-to-end model and the why behind it: the central-vs-repo split, the review lifecycle, and the per-repo tradeoffs. **Start here.** |
> | 👉 **[Fan-out owner guidance](https://docs.google.com/document/d/15MPhvRh4Ifxr7VZnIiD2xxoWy_mjv1naeKW4IQLa3iU/edit?usp=sharing)** | The new ownership model, central-vs-repo boundaries, and the review-lifecycle expectations. |
> | 👉 **[Rollout inventory](https://docs.google.com/document/d/1kqhRjzDz0_7a4z4nRZMyD-yQWL6ZEZC_dztz8yhb4K0/edit?usp=sharing)** | Exactly what moved out of central and what landed in each repo — find this repo's section for the full scope. |
>
> Tracking epic: **[LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)**.

## Why — the new architecture

**Central finds the right owner and explains the shared platform; each repo explains itself.** The central `lfx-skills` plugin keeps only genuinely-central surfaces: cross-repo routing, platform architecture, shared integration guidance, global workflows, and reviewer-agent distribution. Repo-specific implementation truth — conventions, generated-code boundaries, endpoint workflows, contracts, and chart defaults — now lives in the owning repo, where it changes together with the contracts, tests, and charts it describes.

This fixes the drift problem a central rulebook creates: it either grows until it contains repo-specific exceptions for every service, or stays short and goes stale. Where a repo has a review lifecycle, its repo-specific reviewer agents are packaged centrally (so they're available by name in any Claude runtime) but read **evidence this repo owns** — its `CLAUDE.md`, skills, rules, contracts, checklists, and review KB.

## Changes in this repo

This repo owns the generic indexer envelope/contract consumed by every publishing service, so doc accuracy is high-value.

- Repo-local skills: `indexer-service-dev` (Clean-Architecture NATS consumer, layer boundaries, OpenSearch storage, mocks, tests) and `indexer-publishing` (the write-path/publisher contract).
- Repo-local rule: `indexer-contract`.
- Owned docs: `docs/indexer-contract.md` (generic `IndexerMessageEnvelope` / `IndexingConfig`, subjects, OpenSearch document write behavior) and `docs/client-guide.md`.
- `CLAUDE.md` routes platform/topology questions to the central skills and keeps the indexer contract repo-owned.

> This branch is current with `main`.

### Kept current with `main` (2026-06-11)

This branch was re-merged with the latest `main` and the guidance re-audited against the current code. One wording fix landed: handlers only reply OK/ERROR when the message carries a reply subject, and the conventions checklist now says so.

## Reference links

- **Jira epic:** [LFXV2-2015](https://linuxfoundation.atlassian.net/browse/LFXV2-2015)
- **Owner guidance** — steady-state ownership + review lifecycle: [Owner guidance (Google Doc)](https://docs.google.com/document/d/15MPhvRh4Ifxr7VZnIiD2xxoWy_mjv1naeKW4IQLa3iU/edit?usp=sharing)
- **Rollout inventory** — per-repo "what changed": [Rollout inventory (Google Doc)](https://docs.google.com/document/d/1kqhRjzDz0_7a4z4nRZMyD-yQWL6ZEZC_dztz8yhb4K0/edit?usp=sharing)
- **Fan-out architecture** — the model and the why: [Fan-out architecture (Google Doc)](https://docs.google.com/document/d/10eZy8n5xgU7LratcntjkUjGSZmuHpO0xUkskJbJPkfc/edit?usp=sharing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LFXV2-2015]: https://linuxfoundation.atlassian.net/browse/LFXV2-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2015]: https://linuxfoundation.atlassian.net/browse/LFXV2-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
