### PR TITLE
[LFXV2-1743] feat(otel): add NATS span instrumentation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/sdk/log v0.16.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -261,7 +261,7 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 				replyFunc = func(replyData []byte) error {
 					logger.Debug("Sending reply to NATS message", "reply_subject", replySubject, "reply_size", len(replyData))
 					// Create a Producer span for the reply and inject trace context into headers
-					_, replySpan := tracer.Start(spanCtx, "nats.reply.publish",
+					replyCtx, replySpan := tracer.Start(spanCtx, "nats.reply.publish",
 						trace.WithSpanKind(trace.SpanKindProducer),
 						trace.WithAttributes(
 							attribute.String("messaging.system", "nats"),
@@ -274,7 +274,7 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 					replyMsg := nats.NewMsg(replySubject)
 					replyMsg.Header = make(nats.Header)
 					replyMsg.Data = replyData
-					otel.GetTextMapPropagator().Inject(spanCtx, natsHeaderCarrier(replyMsg.Header))
+					otel.GetTextMapPropagator().Inject(replyCtx, natsHeaderCarrier(replyMsg.Header))
 
 					if err := r.conn.PublishMsg(replyMsg); err != nil {
 						replySpan.RecordError(err)

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -85,8 +85,8 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
-		// Extract trace context from incoming message headers.
-		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
+		// Extract trace context from incoming message headers, preserving cancellation/deadline from ctx.
+		msgCtx := otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(msg.Header))
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
 		r.wg.Add(1)
@@ -156,8 +156,8 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
-		// Extract trace context from incoming message headers.
-		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
+		// Extract trace context from incoming message headers, preserving cancellation/deadline from ctx.
+		msgCtx := otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(msg.Header))
 		// Deep-copy message data before handing off to goroutine
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
@@ -228,8 +228,8 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 
 	// Create the NATS message handler with reply support
 	natsHandler := func(msg *nats.Msg) {
-		// Extract trace context from incoming message headers.
-		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
+		// Extract trace context from incoming message headers, preserving cancellation/deadline from ctx.
+		msgCtx := otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(msg.Header))
 		// Deep-copy fields before msg may be reused after callback returns
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
@@ -260,10 +260,29 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 			if replySubject != "" {
 				replyFunc = func(replyData []byte) error {
 					logger.Debug("Sending reply to NATS message", "reply_subject", replySubject, "reply_size", len(replyData))
-					if err := r.conn.Publish(replySubject, replyData); err != nil {
+					// Create a Producer span for the reply and inject trace context into headers
+					_, replySpan := tracer.Start(spanCtx, "nats.reply.publish",
+						trace.WithSpanKind(trace.SpanKindProducer),
+						trace.WithAttributes(
+							attribute.String("messaging.system", "nats"),
+							attribute.String("messaging.destination.name", replySubject),
+							attribute.Int("messaging.message.body.size", len(replyData)),
+						),
+					)
+					defer replySpan.End()
+
+					replyMsg := nats.NewMsg(replySubject)
+					replyMsg.Header = make(nats.Header)
+					replyMsg.Data = replyData
+					otel.GetTextMapPropagator().Inject(spanCtx, natsHeaderCarrier(replyMsg.Header))
+
+					if err := r.conn.PublishMsg(replyMsg); err != nil {
+						replySpan.RecordError(err)
+						replySpan.SetStatus(codes.Error, err.Error())
 						logger.Error("Failed to send reply", "reply_subject", replySubject, "error", err.Error())
 						return err
 					}
+					replySpan.SetStatus(codes.Ok, "")
 					return nil
 				}
 			}

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -12,6 +12,10 @@ import (
 	"time"
 
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/linuxfoundation/lfx-v2-indexer-service/internal/domain/contracts"
 	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
@@ -81,6 +85,8 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
+		// Extract trace context from incoming message headers.
+		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
 		r.wg.Add(1)
@@ -91,11 +97,25 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 				r.wg.Done()
 			}()
 
-			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+			spanCtx, span := tracer.Start(msgCtx, "nats.process",
+				trace.WithSpanKind(trace.SpanKindConsumer),
+				trace.WithAttributes(
+					attribute.String("messaging.system", "nats"),
+					attribute.String("messaging.destination.name", msgSubject),
+					attribute.Int("messaging.message.body.size", len(data)),
+				),
+			)
+			defer span.End()
+
+			spanCtx, logger := logging.WithRequestID(spanCtx, r.logger)
 			logger.Debug("NATS message received", "subject", msgSubject, "size", len(data))
 
-			if err := handler.Handle(ctx, data, msgSubject); err != nil {
+			if err := handler.Handle(spanCtx, data, msgSubject); err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
 				logger.Error("Message handler failed", "error", err.Error())
+			} else {
+				span.SetStatus(codes.Ok, "")
 			}
 		}()
 	}
@@ -136,6 +156,8 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 
 	// Create the NATS message handler
 	natsHandler := func(msg *nats.Msg) {
+		// Extract trace context from incoming message headers.
+		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
 		// Deep-copy message data before handing off to goroutine
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
@@ -147,11 +169,25 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 				r.wg.Done()
 			}()
 
-			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+			spanCtx, span := tracer.Start(msgCtx, "nats.process",
+				trace.WithSpanKind(trace.SpanKindConsumer),
+				trace.WithAttributes(
+					attribute.String("messaging.system", "nats"),
+					attribute.String("messaging.destination.name", msgSubject),
+					attribute.Int("messaging.message.body.size", len(data)),
+				),
+			)
+			defer span.End()
+
+			spanCtx, logger := logging.WithRequestID(spanCtx, r.logger)
 			logger.Debug("NATS queue message received", "subject", msgSubject, "queue", queue, "size", len(data))
 
-			if err := handler.Handle(ctx, data, msgSubject); err != nil {
+			if err := handler.Handle(spanCtx, data, msgSubject); err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
 				logger.Error("Queue message handler failed", "queue", queue, "error", err.Error())
+			} else {
+				span.SetStatus(codes.Ok, "")
 			}
 		}()
 	}
@@ -192,6 +228,8 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 
 	// Create the NATS message handler with reply support
 	natsHandler := func(msg *nats.Msg) {
+		// Extract trace context from incoming message headers.
+		msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
 		// Deep-copy fields before msg may be reused after callback returns
 		data := append([]byte(nil), msg.Data...)
 		msgSubject := msg.Subject
@@ -205,7 +243,17 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 				r.wg.Done()
 			}()
 
-			ctx, logger := logging.WithRequestID(context.Background(), r.logger)
+			spanCtx, span := tracer.Start(msgCtx, "nats.process",
+				trace.WithSpanKind(trace.SpanKindConsumer),
+				trace.WithAttributes(
+					attribute.String("messaging.system", "nats"),
+					attribute.String("messaging.destination.name", msgSubject),
+					attribute.Int("messaging.message.body.size", len(data)),
+				),
+			)
+			defer span.End()
+
+			spanCtx, logger := logging.WithRequestID(spanCtx, r.logger)
 			logger.Debug("NATS queue message with reply received", "subject", msgSubject, "queue", queue, "has_reply", replySubject != "")
 
 			var replyFunc func([]byte) error
@@ -220,8 +268,12 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 				}
 			}
 
-			if err := handler.HandleWithReply(ctx, data, msgSubject, replyFunc); err != nil {
+			if err := handler.HandleWithReply(spanCtx, data, msgSubject, replyFunc); err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
 				logger.Error("Queue message with reply handler failed", "queue", queue, "error", err.Error())
+			} else {
+				span.SetStatus(codes.Ok, "")
 			}
 		}()
 	}
@@ -257,11 +309,28 @@ func (r *MessagingRepository) Publish(ctx context.Context, subject string, data 
 		return fmt.Errorf("NATS connection not available for publishing to subject %s", subject)
 	}
 
-	if err := r.conn.Publish(subject, data); err != nil {
+	ctx, span := tracer.Start(ctx, "nats.publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", subject),
+			attribute.Int("messaging.message.body.size", len(data)),
+		),
+	)
+	defer span.End()
+
+	msg := nats.NewMsg(subject)
+	msg.Data = data
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
+
+	if err := r.conn.PublishMsg(msg); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		logger.Error("Failed to publish message to NATS", "subject", subject, "error", err.Error())
 		return fmt.Errorf("failed to publish message to subject %s: %w", subject, err)
 	}
 
+	span.SetStatus(codes.Ok, "")
 	logger.Debug("Message published to NATS successfully", "subject", subject, "size", len(data))
 	return nil
 }

--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -320,6 +320,7 @@ func (r *MessagingRepository) Publish(ctx context.Context, subject string, data 
 	defer span.End()
 
 	msg := nats.NewMsg(subject)
+	msg.Header = make(nats.Header)
 	msg.Data = data
 	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
 

--- a/internal/infrastructure/messaging/tracing.go
+++ b/internal/infrastructure/messaging/tracing.go
@@ -27,6 +27,9 @@ func (c natsHeaderCarrier) Get(key string) string {
 }
 
 func (c natsHeaderCarrier) Set(key string, value string) {
+	if c == nil {
+		return
+	}
 	c[key] = []string{value}
 }
 

--- a/internal/infrastructure/messaging/tracing.go
+++ b/internal/infrastructure/messaging/tracing.go
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package messaging
+
+import (
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// tracer is safe to initialize at package level — otel.Tracer() returns a
+// delegating tracer that forwards to whatever TracerProvider is registered at
+// call time, so otel.SetTracerProvider() updates it regardless of init order.
+var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/messaging")
+
+// natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
+// so trace context can be injected/extracted from NATS message headers.
+type natsHeaderCarrier nats.Header
+
+func (c natsHeaderCarrier) Get(key string) string {
+	vals := c[key]
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+func (c natsHeaderCarrier) Set(key string, value string) {
+	c[key] = []string{value}
+}
+
+func (c natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}

--- a/internal/infrastructure/messaging/tracing_test.go
+++ b/internal/infrastructure/messaging/tracing_test.go
@@ -167,6 +167,9 @@ func TestTraceContextExtraction(t *testing.T) {
 			// Handler was called, now verify spans
 			time.Sleep(100 * time.Millisecond) // Allow spans to be exported
 
+			// Flush the batch processor to ensure spans are exported before asserting.
+			tp.ForceFlush(context.Background())
+
 			// Check that both publish and process spans exist
 			spans := exporter.GetSpans()
 			processSpanFound := false
@@ -235,9 +238,16 @@ func TestTraceContextPreservation(t *testing.T) {
 		// Wait for the handler to be called
 		select {
 		case handlerCtx := <-contextReceived:
-			// Verify that the handler context has trace information
-			// (Extract adds trace span context while preserving the original context)
+			// Verify that the handler context is non-nil.
 			assert.NotNil(t, handlerCtx)
+
+			// Verify that the handler context preserves the deadline from the Subscribe ctx.
+			expectedDeadline, expectedHasDeadline := ctxWithDeadline.Deadline()
+			actualDeadline, actualHasDeadline := handlerCtx.Deadline()
+			assert.Equal(t, expectedHasDeadline, actualHasDeadline, "deadline presence should be preserved")
+			if expectedHasDeadline && actualHasDeadline {
+				assert.Equal(t, expectedDeadline, actualDeadline, "deadline should be preserved in handler context")
+			}
 
 		case <-time.After(2 * time.Second):
 			t.Fatal("Handler not called within timeout")

--- a/internal/infrastructure/messaging/tracing_test.go
+++ b/internal/infrastructure/messaging/tracing_test.go
@@ -94,6 +94,9 @@ func TestTraceContextInjection(t *testing.T) {
 		err := repo.Publish(ctx, subject, data)
 		require.NoError(t, err)
 
+		// Flush the batch processor to ensure spans are exported
+		tp.ForceFlush(context.Background())
+
 		// Verify that a span was created
 		spans := exporter.GetSpans()
 		require.Greater(t, len(spans), 0)
@@ -295,8 +298,9 @@ func TestReplyPublishTraceContext(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Create a request-reply subscription to receive the reply
+		replyInbox := nats.NewInbox()
 		replyChan := make(chan *nats.Msg, 1)
-		_, err = conn.Subscribe(nats.NewInbox(), func(msg *nats.Msg) {
+		_, err = conn.Subscribe(replyInbox, func(msg *nats.Msg) {
 			replyChan <- msg
 		})
 		require.NoError(t, err)
@@ -304,7 +308,6 @@ func TestReplyPublishTraceContext(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Publish a request-reply message
-		replyInbox := nats.NewInbox()
 		requestMsg := nats.NewMsg(requestSubject)
 		requestMsg.Header = make(nats.Header)
 		requestMsg.Data = testData
@@ -317,6 +320,9 @@ func TestReplyPublishTraceContext(t *testing.T) {
 		select {
 		case <-replyReceived:
 			time.Sleep(100 * time.Millisecond) // Allow spans to be exported
+
+			// Flush the batch processor to ensure spans are exported
+			tp.ForceFlush(context.Background())
 
 			// Verify that reply.publish span was created
 			spans := exporter.GetSpans()

--- a/internal/infrastructure/messaging/tracing_test.go
+++ b/internal/infrastructure/messaging/tracing_test.go
@@ -1,0 +1,385 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package messaging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	sdktrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-indexer-service/pkg/logging"
+)
+
+// TestNatsHeaderCarrier verifies the natsHeaderCarrier implements TextMapCarrier correctly
+func TestNatsHeaderCarrier(t *testing.T) {
+	t.Run("get_empty_header", func(t *testing.T) {
+		carrier := natsHeaderCarrier(nats.Header{})
+		val := carrier.Get("X-Trace-ID")
+		assert.Equal(t, "", val)
+	})
+
+	t.Run("get_existing_header", func(t *testing.T) {
+		header := nats.Header{
+			"X-Trace-ID": []string{"trace-123"},
+		}
+		carrier := natsHeaderCarrier(header)
+		val := carrier.Get("X-Trace-ID")
+		assert.Equal(t, "trace-123", val)
+	})
+
+	t.Run("set_header", func(t *testing.T) {
+		header := nats.Header{}
+		carrier := natsHeaderCarrier(header)
+		carrier.Set("X-Trace-ID", "trace-456")
+		assert.Equal(t, "trace-456", header["X-Trace-ID"][0])
+	})
+
+	t.Run("keys", func(t *testing.T) {
+		header := nats.Header{
+			"X-Trace-ID":  []string{"trace-123"},
+			"X-Span-ID":   []string{"span-456"},
+			"X-User-ID":   []string{"user-789"},
+		}
+		carrier := natsHeaderCarrier(header)
+		keys := carrier.Keys()
+		assert.Len(t, keys, 3)
+		assert.Contains(t, keys, "X-Trace-ID")
+		assert.Contains(t, keys, "X-Span-ID")
+		assert.Contains(t, keys, "X-User-ID")
+	})
+}
+
+// TestTraceContextInjection verifies that trace context is injected into message headers during publish
+func TestTraceContextInjection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	conn, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		t.Skipf("Skipping test: no NATS server available: %v", err)
+	}
+	defer conn.Close()
+
+	// Setup OTel with test exporter to capture spans
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithBatcher(exporter))
+	defer tp.Shutdown(context.Background())
+	otel.SetTracerProvider(tp)
+
+	logger := logging.NewLogger(true)
+	repo := NewMessagingRepository(conn, nil, logger, 5*time.Second,
+		constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit,
+		constants.DefaultWorkerCount)
+	defer repo.Close()
+
+	ctx := context.Background()
+
+	t.Run("publish_injects_trace_context", func(t *testing.T) {
+		subject := "test.trace.publish"
+		data := []byte("test message")
+
+		// Publish a message with active trace context
+		err := repo.Publish(ctx, subject, data)
+		require.NoError(t, err)
+
+		// Verify that a span was created
+		spans := exporter.GetSpans()
+		require.Greater(t, len(spans), 0)
+
+		// Find the publish span
+		var publishSpan *tracetest.SpanStub
+		for _, s := range spans {
+			if s.Name == "nats.publish" {
+				publishSpan = &s
+				break
+			}
+		}
+		require.NotNil(t, publishSpan, "Expected to find nats.publish span")
+		assert.Equal(t, sdktrace.SpanKindProducer, publishSpan.SpanKind)
+	})
+}
+
+// TestTraceContextExtraction verifies that subscriber handlers extract trace context from headers
+func TestTraceContextExtraction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	conn, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		t.Skipf("Skipping test: no NATS server available: %v", err)
+	}
+	defer conn.Close()
+
+	// Setup OTel with test exporter
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithBatcher(exporter))
+	defer tp.Shutdown(context.Background())
+	otel.SetTracerProvider(tp)
+
+	logger := logging.NewLogger(true)
+	repo := NewMessagingRepository(conn, nil, logger, 5*time.Second,
+		constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit,
+		constants.DefaultWorkerCount)
+	defer repo.Close()
+
+	ctx := context.Background()
+
+	t.Run("subscribe_extracts_trace_context", func(t *testing.T) {
+		subject := "test.trace.subscribe"
+		testData := []byte("trace test message")
+		handlerCalled := make(chan bool, 1)
+
+		mockHandler := &MockMessageHandler{}
+		mockHandler.On("Handle", mock.Anything, testData, subject).Run(func(_ mock.Arguments) {
+			handlerCalled <- true
+		}).Return(nil)
+
+		// Subscribe to the subject
+		err := repo.Subscribe(ctx, subject, mockHandler)
+		require.NoError(t, err)
+
+		// Give subscription time to be established
+		time.Sleep(100 * time.Millisecond)
+
+		// Publish message with trace headers
+		err = repo.Publish(ctx, subject, testData)
+		require.NoError(t, err)
+
+		// Wait for message to be received
+		select {
+		case <-handlerCalled:
+			// Handler was called, now verify spans
+			time.Sleep(100 * time.Millisecond) // Allow spans to be exported
+
+			// Check that both publish and process spans exist
+			spans := exporter.GetSpans()
+			processSpanFound := false
+			for _, s := range spans {
+				if s.Name == "nats.process" && s.SpanKind == sdktrace.SpanKindConsumer {
+					processSpanFound = true
+					break
+				}
+			}
+			assert.True(t, processSpanFound, "Expected to find nats.process span with Consumer kind")
+
+		case <-time.After(2 * time.Second):
+			t.Fatal("Handler not called within timeout")
+		}
+
+		mockHandler.AssertExpectations(t)
+	})
+}
+
+// TestTraceContextPreservation verifies that cancellation and deadline from context are preserved
+func TestTraceContextPreservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	conn, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		t.Skipf("Skipping test: no NATS server available: %v", err)
+	}
+	defer conn.Close()
+
+	logger := logging.NewLogger(true)
+	repo := NewMessagingRepository(conn, nil, logger, 5*time.Second,
+		constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit,
+		constants.DefaultWorkerCount)
+	defer repo.Close()
+
+	t.Run("subscribe_preserves_context_deadline", func(t *testing.T) {
+		subject := "test.context.deadline"
+		testData := []byte("deadline test")
+
+		// Create context with deadline
+		ctxWithDeadline, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		contextReceived := make(chan context.Context, 1)
+
+		mockHandler := &MockMessageHandler{}
+		mockHandler.On("Handle", mock.Anything, testData, subject).Run(func(args mock.Arguments) {
+			// Capture the context passed to the handler
+			receivedCtx := args.Get(0).(context.Context)
+			contextReceived <- receivedCtx
+		}).Return(nil)
+
+		// Subscribe with a context that has a deadline
+		err := repo.Subscribe(ctxWithDeadline, subject, mockHandler)
+		require.NoError(t, err)
+
+		// Give subscription time to be established
+		time.Sleep(100 * time.Millisecond)
+
+		// Publish message
+		err = repo.Publish(context.Background(), subject, testData)
+		require.NoError(t, err)
+
+		// Wait for the handler to be called
+		select {
+		case handlerCtx := <-contextReceived:
+			// Verify that the handler context has trace information
+			// (Extract adds trace span context while preserving the original context)
+			assert.NotNil(t, handlerCtx)
+
+		case <-time.After(2 * time.Second):
+			t.Fatal("Handler not called within timeout")
+		}
+	})
+}
+
+// TestReplyPublishTraceContext verifies that reply messages carry trace context
+func TestReplyPublishTraceContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	conn, err := nats.Connect(nats.DefaultURL)
+	if err != nil {
+		t.Skipf("Skipping test: no NATS server available: %v", err)
+	}
+	defer conn.Close()
+
+	// Setup OTel with test exporter
+	exporter := tracetest.NewInMemoryExporter()
+	tp := trace.NewTracerProvider(trace.WithBatcher(exporter))
+	defer tp.Shutdown(context.Background())
+	otel.SetTracerProvider(tp)
+
+	logger := logging.NewLogger(true)
+	repo := NewMessagingRepository(conn, nil, logger, 5*time.Second,
+		constants.DefaultPendingMsgLimit, constants.DefaultPendingBytesLimit,
+		constants.DefaultWorkerCount)
+	defer repo.Close()
+
+	ctx := context.Background()
+
+	t.Run("queue_subscribe_with_reply_injects_trace", func(t *testing.T) {
+		requestSubject := "test.request.reply"
+		queue := "test.reply.queue"
+		testData := []byte("request data")
+		replyReceived := make(chan bool, 1)
+
+		replyData := []byte("reply response")
+
+		mockHandler := &MockMessageHandlerWithReply{}
+		mockHandler.On("HandleWithReply", mock.Anything, testData, requestSubject, mock.Anything).
+			Run(func(args mock.Arguments) {
+				// Get the reply function and call it
+				replyFunc := args.Get(3).(func([]byte) error)
+				err := replyFunc(replyData)
+				if err == nil {
+					replyReceived <- true
+				}
+			}).Return(nil)
+
+		// Subscribe with reply support
+		err := repo.QueueSubscribeWithReply(ctx, requestSubject, queue, mockHandler)
+		require.NoError(t, err)
+
+		// Give subscription time to be established
+		time.Sleep(100 * time.Millisecond)
+
+		// Create a request-reply subscription to receive the reply
+		replyChan := make(chan *nats.Msg, 1)
+		_, err = conn.Subscribe(nats.NewInbox(), func(msg *nats.Msg) {
+			replyChan <- msg
+		})
+		require.NoError(t, err)
+
+		time.Sleep(100 * time.Millisecond)
+
+		// Publish a request-reply message
+		replyInbox := nats.NewInbox()
+		requestMsg := nats.NewMsg(requestSubject)
+		requestMsg.Header = make(nats.Header)
+		requestMsg.Data = testData
+		requestMsg.Reply = replyInbox
+
+		err = conn.PublishMsg(requestMsg)
+		require.NoError(t, err)
+
+		// Wait for handler to be called and reply to be sent
+		select {
+		case <-replyReceived:
+			time.Sleep(100 * time.Millisecond) // Allow spans to be exported
+
+			// Verify that reply.publish span was created
+			spans := exporter.GetSpans()
+			replySpanFound := false
+			for _, s := range spans {
+				if s.Name == "nats.reply.publish" && s.SpanKind == sdktrace.SpanKindProducer {
+					replySpanFound = true
+					break
+				}
+			}
+			assert.True(t, replySpanFound, "Expected to find nats.reply.publish span with Producer kind")
+
+		case <-time.After(2 * time.Second):
+			t.Fatal("Reply not sent within timeout")
+		}
+
+		mockHandler.AssertExpectations(t)
+	})
+}
+
+// TestHeaderCarrierCompatibility verifies the header carrier interface works correctly
+func TestHeaderCarrierCompatibility(t *testing.T) {
+	header := nats.Header{}
+	carrier := natsHeaderCarrier(header)
+
+	t.Run("carrier_set_and_get", func(t *testing.T) {
+		// Verify Set/Get works
+		carrier.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+		value := carrier.Get("traceparent")
+		assert.Equal(t, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", value)
+	})
+
+	t.Run("carrier_keys", func(t *testing.T) {
+		// Add multiple headers
+		carrier.Set("x-trace-id", "trace-123")
+		carrier.Set("x-span-id", "span-456")
+		keys := carrier.Keys()
+		assert.Len(t, keys, 3) // traceparent, x-trace-id, x-span-id
+		assert.Contains(t, keys, "traceparent")
+		assert.Contains(t, keys, "x-trace-id")
+		assert.Contains(t, keys, "x-span-id")
+	})
+
+	t.Run("propagator_inject_extract", func(t *testing.T) {
+		// Setup OTel with test provider to ensure propagator is initialized
+		exporter := tracetest.NewInMemoryExporter()
+		tp := trace.NewTracerProvider(trace.WithBatcher(exporter))
+		defer tp.Shutdown(context.Background())
+		otel.SetTracerProvider(tp)
+
+		propagator := otel.GetTextMapPropagator()
+
+		// Simulate injecting trace context
+		freshHeader := nats.Header{}
+		freshCarrier := natsHeaderCarrier(freshHeader)
+		ctx, span := otel.Tracer("test").Start(context.Background(), "test-span")
+		defer span.End()
+
+		propagator.Inject(ctx, freshCarrier)
+
+		// Verify we can extract it back (propagator should work with carrier)
+		extractedCtx := propagator.Extract(context.Background(), freshCarrier)
+		assert.NotNil(t, extractedCtx)
+		// The important thing is that the carrier interface works without panicking
+	})
+}

--- a/internal/infrastructure/messaging/tracing_test.go
+++ b/internal/infrastructure/messaging/tracing_test.go
@@ -47,9 +47,9 @@ func TestNatsHeaderCarrier(t *testing.T) {
 
 	t.Run("keys", func(t *testing.T) {
 		header := nats.Header{
-			"X-Trace-ID":  []string{"trace-123"},
-			"X-Span-ID":   []string{"span-456"},
-			"X-User-ID":   []string{"user-789"},
+			"X-Trace-ID": []string{"trace-123"},
+			"X-Span-ID":  []string{"span-456"},
+			"X-User-ID":  []string{"user-789"},
 		}
 		carrier := natsHeaderCarrier(header)
 		keys := carrier.Keys()


### PR DESCRIPTION
## Summary

- Add `tracing.go` with `natsHeaderCarrier` (OTel TextMapCarrier adaptor) and package-level `tracer`
- Wrap NATS publish operations with Producer spans, injecting trace context into message headers
- Wrap NATS reply operations with Producer spans, properly injecting from reply-specific span context
- Initialize message header map before trace context injection to prevent nil map panic
- Add Consumer span extraction in subscriber handlers, preserving cancellation and deadline from context

## Test plan

- [ ] `make build` passes
- [ ] Trace spans appear in Datadog APM for NATS-triggered operations