### PR TITLE
fix: de-duplicate tags in indexed documents (LFXV2-2465)

### DIFF
--- a/internal/domain/services/indexer_service.go
+++ b/internal/domain/services/indexer_service.go
@@ -1278,7 +1278,9 @@ func (s *IndexerService) buildTransactionBodyFromIndexingConfig(
 	body.SortName = config.SortName
 	body.NameAndAliases = config.NameAndAliases
 	body.ParentRefs = config.ParentRefs
-	body.Tags = append(transaction.Tags, config.Tags...)
+	// Producers may set the same tags in both the top-level message and
+	// indexing_config, so de-duplicate to avoid doubled tags in the index.
+	body.Tags = dedupeStrings(append(transaction.Tags, config.Tags...))
 	body.Fulltext = config.Fulltext
 	body.Contacts = config.Contacts
 
@@ -1300,6 +1302,24 @@ func (s *IndexerService) buildTransactionBodyFromIndexingConfig(
 	slog.Debug("Built transaction body from indexing config", "body", body)
 
 	return body, nil
+}
+
+// dedupeStrings returns the order-preserving, first-occurrence union of the
+// input, dropping later duplicates.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // expandTemplates recursively expands template variables in the format {{ field_name }}

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -1048,6 +1048,52 @@ func TestIndexerService_buildTransactionBodyFromIndexingConfig(t *testing.T) {
 				assert.Equal(t, "committee:committee-123#admin", body.HistoryCheckQuery)
 			},
 		},
+		{
+			name: "tags overlapping between transaction and config are de-duplicated",
+			data: map[string]any{
+				"id": "org-dup",
+			},
+			config: &types.IndexingConfig{
+				ObjectID:             "org-dup",
+				AccessCheckObject:    "b2b_org:org-dup",
+				AccessCheckRelation:  "viewer",
+				HistoryCheckObject:   "b2b_org:org-dup",
+				HistoryCheckRelation: "historian",
+				Tags:                 []string{"a", "b", "c"},
+			},
+			transaction: &contracts.LFXTransaction{
+				Action:     constants.ActionCreated,
+				ObjectType: "b2b_org",
+				Timestamp:  time.Now(),
+				Tags:       []string{"a", "b"},
+			},
+			validate: func(t *testing.T, body *contracts.TransactionBody) {
+				assert.Equal(t, []string{"a", "b", "c"}, body.Tags)
+			},
+		},
+		{
+			name: "tags with no overlap are unioned in order",
+			data: map[string]any{
+				"id": "org-union",
+			},
+			config: &types.IndexingConfig{
+				ObjectID:             "org-union",
+				AccessCheckObject:    "b2b_org:org-union",
+				AccessCheckRelation:  "viewer",
+				HistoryCheckObject:   "b2b_org:org-union",
+				HistoryCheckRelation: "historian",
+				Tags:                 []string{"c", "d"},
+			},
+			transaction: &contracts.LFXTransaction{
+				Action:     constants.ActionCreated,
+				ObjectType: "b2b_org",
+				Timestamp:  time.Now(),
+				Tags:       []string{"a", "b"},
+			},
+			validate: func(t *testing.T, body *contracts.TransactionBody) {
+				assert.Equal(t, []string{"a", "b", "c", "d"}, body.Tags)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1059,6 +1105,25 @@ func TestIndexerService_buildTransactionBodyFromIndexingConfig(t *testing.T) {
 			if tt.validate != nil {
 				tt.validate(t, body)
 			}
+		})
+	}
+}
+
+func TestDedupeStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       []string
+		expected []string
+	}{
+		{name: "overlapping union collapses duplicates", in: []string{"a", "b", "a", "b", "c"}, expected: []string{"a", "b", "c"}},
+		{name: "no duplicates preserved in order", in: []string{"a", "b", "c", "d"}, expected: []string{"a", "b", "c", "d"}},
+		{name: "empty input", in: []string{}, expected: []string{}},
+		{name: "nil input", in: nil, expected: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, dedupeStrings(tt.in))
 		})
 	}
 }

--- a/internal/domain/services/indexer_service_test.go
+++ b/internal/domain/services/indexer_service_test.go
@@ -1117,6 +1117,8 @@ func TestDedupeStrings(t *testing.T) {
 	}{
 		{name: "overlapping union collapses duplicates", in: []string{"a", "b", "a", "b", "c"}, expected: []string{"a", "b", "c"}},
 		{name: "no duplicates preserved in order", in: []string{"a", "b", "c", "d"}, expected: []string{"a", "b", "c", "d"}},
+		{name: "single element", in: []string{"a"}, expected: []string{"a"}},
+		{name: "all duplicates", in: []string{"a", "a", "a"}, expected: []string{"a"}},
 		{name: "empty input", in: []string{}, expected: []string{}},
 		{name: "nil input", in: nil, expected: nil},
 	}


### PR DESCRIPTION
## Summary

Every document the indexer writes to OpenSearch has its `tags` array **duplicated** — each tag appears exactly twice. Confirmed in prod: a `b2b_org_settings` doc shows `has_writers`/`has_auditors`/`has_pending_invites` twice each and `writer:`/`auditor:`/`member:` tags at exactly 2× their true counts (e.g. 48 writer tags for 24 real writers); a `b2b_org` doc shows `b2b_org_uid:<id>` and `is_member:false` twice.

## Root cause

In `internal/domain/services/indexer_service.go`, `buildTransactionBodyFromIndexingConfig` built `body.Tags` by concatenating the top-level message tags with the indexing_config tags with **no de-duplication**:

```go
body.Tags = append(transaction.Tags, config.Tags...)
```

- `transaction.Tags` comes from the top-level message `tags` field.
- `config.Tags` comes from `indexing_config.tags`.

Producers (e.g. `lfx-v2-member-service`) set the **same** tag list in **both** the top-level `tags` field and `indexing_config.tags`, so this concat doubles every tag for every object type (`b2b_org`, `b2b_org_settings`, `project_membership`, `key_contact`, `workspaces`, `workspace_projects`).

## Fix (defensive de-dup at the consumer)

`body.Tags` is now the **order-preserving, first-occurrence de-duplicated union** of `transaction.Tags` and `config.Tags`, via a small `dedupeStrings` helper. This keeps the indexer correct regardless of whether a producer sets tags in one place or both.

## Follow-ups (not in this PR)

- **Producer fix (recommended):** `lfx-v2-member-service` (`messaging.go`) double-sets tags in both the top-level `tags` field and `indexing_config.tags`. Stopping the producer from setting tags twice would address the root at the source; this consumer-side dedupe makes the indexer robust either way.
- **Backfill/reindex:** existing OpenSearch documents already carry doubled tags. They will need a reindex/backfill to clean the previously-doubled tags. **Not performed here.**

## Test plan

- [x] New table cases in `TestIndexerService_buildTransactionBodyFromIndexingConfig` proving overlapping `transaction.Tags`+`config.Tags` collapse (`["a","b"]` + `["a","b","c"]` → `["a","b","c"]`) and the no-overlap union case (`["a","b"]` + `["c","d"]` → `["a","b","c","d"]`), order preserved.
- [x] New `TestDedupeStrings` covering overlap, no-dupes, empty, and nil inputs.
- [x] `gofmt`/`goimports` clean, `go vet`, `go build ./...`, `go test ./internal/domain/services/`, `golangci-lint run` — all green.

Ref: LFXV2-2465

Made with [Cursor](https://cursor.com)