### PR TITLE
feat(nats): add NATS span instrumentation to indexer-service

### DIFF
--- a/internal/infrastructure/messaging/messaging_repository.go
+++ b/internal/infrastructure/messaging/messaging_repository.go
@@ -102,6 +102,7 @@ func (r *MessagingRepository) Subscribe(ctx context.Context, subject string, han
 				trace.WithAttributes(
 					attribute.String("messaging.system", "nats"),
 					attribute.String("messaging.destination.name", msgSubject),
+					attribute.String("messaging.operation.type", "process"),
 					attribute.Int("messaging.message.body.size", len(data)),
 				),
 			)
@@ -174,6 +175,7 @@ func (r *MessagingRepository) QueueSubscribe(ctx context.Context, subject string
 				trace.WithAttributes(
 					attribute.String("messaging.system", "nats"),
 					attribute.String("messaging.destination.name", msgSubject),
+					attribute.String("messaging.operation.type", "process"),
 					attribute.Int("messaging.message.body.size", len(data)),
 				),
 			)
@@ -248,6 +250,7 @@ func (r *MessagingRepository) QueueSubscribeWithReply(ctx context.Context, subje
 				trace.WithAttributes(
 					attribute.String("messaging.system", "nats"),
 					attribute.String("messaging.destination.name", msgSubject),
+					attribute.String("messaging.operation.type", "process"),
 					attribute.Int("messaging.message.body.size", len(data)),
 				),
 			)

--- a/internal/infrastructure/messaging/tracing.go
+++ b/internal/infrastructure/messaging/tracing.go
@@ -4,7 +4,7 @@
 package messaging
 
 import (
-	"github.com/nats-io/nats.go"
+	natsgo "github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
@@ -15,8 +15,8 @@ import (
 var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/messaging")
 
 // natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
-// so trace context can be injected/extracted from NATS message headers.
-type natsHeaderCarrier nats.Header
+// so trace context can be extracted from NATS message headers.
+type natsHeaderCarrier natsgo.Header
 
 func (c natsHeaderCarrier) Get(key string) string {
 	vals := c[key]

--- a/internal/infrastructure/messaging/tracing.go
+++ b/internal/infrastructure/messaging/tracing.go
@@ -15,7 +15,8 @@ import (
 var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-indexer-service/internal/infrastructure/messaging")
 
 // natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
-// so trace context can be extracted from NATS message headers.
+// for both injecting trace context into outgoing NATS messages and extracting
+// it from incoming ones.
 type natsHeaderCarrier natsgo.Header
 
 func (c natsHeaderCarrier) Get(key string) string {


### PR DESCRIPTION
Adds OTel consumer spans to Subscribe, QueueSubscribe, QueueSubscribeWithReply handlers with trace context propagation from NATS message headers, and OTel producer spans to all Publish operations.

References LFXV2-1743