### PR TITLE
fix: surface reloader annotation on Deployment metadata

### DIFF
--- a/charts/lfx-v2-indexer-service/templates/deployment.yaml
+++ b/charts/lfx-v2-indexer-service/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: lfx
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.app.replicas }}
   selector:

--- a/charts/lfx-v2-indexer-service/values.yaml
+++ b/charts/lfx-v2-indexer-service/values.yaml
@@ -109,6 +109,11 @@ app:
     # (default: "tracecontext,baggage")
     propagators: "tracecontext,baggage,jaeger"
 
+# annotations are additional annotations applied to the Deployment itself.
+# Example:
+#   reloader.stakater.com/auto: "true"
+annotations: {}
+
 # podAnnotations are additional annotations applied to the pod template.
 # Example:
 #   prometheus.io/scrape: "true"


### PR DESCRIPTION
Render .Values.annotations onto the Deployment's top-level metadata so
reloader.stakater.com/auto is actually applied, fixing the "Has Reloader
Annotation" Soundcheck check.